### PR TITLE
hide spinners on disabled number input elements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -256,4 +256,16 @@ export default {
 .container[role="main"] {
 	padding: 60px 15px 30px;
 }
+
+/* Chrome, Safari, Edge, Opera */
+input[readonly]::-webkit-outer-spin-button,
+input[readonly]::-webkit-inner-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+
+/* Firefox */
+input[readonly][type=number] {
+	-moz-appearance: textfield;
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -256,16 +256,4 @@ export default {
 .container[role="main"] {
 	padding: 60px 15px 30px;
 }
-
-/* Chrome, Safari, Edge, Opera */
-input[readonly]::-webkit-outer-spin-button,
-input[readonly]::-webkit-inner-spin-button {
-	-webkit-appearance: none;
-	margin: 0;
-}
-
-/* Firefox */
-input[readonly][type=number] {
-	-moz-appearance: textfield;
-}
 </style>

--- a/src/components/OpenwbBaseNumberInput.vue
+++ b/src/components/OpenwbBaseNumberInput.vue
@@ -94,4 +94,20 @@ input.invalid,
 input:invalid {
 	background-color: pink;
 }
+
+/* hide spinner buttons if input element is readonly or disabled */
+/* Chrome, Safari, Edge, Opera */
+input[readonly]::-webkit-outer-spin-button,
+input[readonly]::-webkit-inner-spin-button,
+input[disabled]::-webkit-outer-spin-button,
+input[disabled]::-webkit-inner-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+
+/* Firefox */
+input[readonly][type="number"],
+input[disabled][type="number"] {
+	-moz-appearance: textfield;
+}
 </style>


### PR DESCRIPTION
- fix for safari and firefox