### PR TITLE
Update OpenwbBaseTextInput.vue :: Einheit bei OpenwbBaseTeytInput mit ausgeben (Statusseite bei den JSON-Feldern)

### DIFF
--- a/src/components/OpenwbBaseTextInput.vue
+++ b/src/components/OpenwbBaseTextInput.vue
@@ -145,6 +145,11 @@
 						v-model="value"
 						v-bind="$attrs"
 					/>
+					<div v-if="unit" class="input-group-append">
+						<div class="input-group-text">
+							{{ unit }}
+						</div>
+					</div>
 				</div>
 			</div>
 			<span v-if="showHelp" class="form-row alert alert-info my-1 small">
@@ -219,6 +224,7 @@ export default {
 			default: "text",
 		},
 		pattern: String,
+		unit: String,
 	},
 	emits: ["update:modelValue"],
 	data() {


### PR DESCRIPTION
Einheit bei OpenwbBaseTeytInput mit ausgeben.
Ist relevant für die Statusseite bei den JSON-Feldern.