### PR TITLE
really fix websocket connection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -151,7 +151,6 @@ export default {
 			// alis Alipay mini app connection
 			const { protocol, host, port, endpoint, ...options } =
 				this.connection;
-			console.log("port:", port);
 			const connectUrl = `${protocol}://${host}:${port}${endpoint}`;
 			console.debug("connecting to broker:", connectUrl);
 			try {

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,8 +42,10 @@ export default {
 			connection: {
 				protocol: location.protocol == "https:" ? "wss" : "ws",
 				host: location.hostname,
-				port: location.port,
-				endpoint: "/ws",
+				port:
+					parseInt(location.port) ||
+					(location.protocol == "https:" ? 443 : 80),
+				endpoint: "/mqtt",
 				connectTimeout: 4000,
 				reconnectPeriod: 4000,
 			},
@@ -149,6 +151,7 @@ export default {
 			// alis Alipay mini app connection
 			const { protocol, host, port, endpoint, ...options } =
 				this.connection;
+			console.log("port:", port);
 			const connectUrl = `${protocol}://${host}:${port}${endpoint}`;
 			console.debug("connecting to broker:", connectUrl);
 			try {

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,7 +42,7 @@ export default {
 			connection: {
 				protocol: location.protocol == "https:" ? "wss" : "ws",
 				host: location.hostname,
-				port: location.protocol == "https:" ? 443 : 80,
+				port: location.port,
 				endpoint: "/ws",
 				connectTimeout: 4000,
 				reconnectPeriod: 4000,

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,6 +5,14 @@ module.exports = {
 	css: {
 		sourceMap: true,
 	},
+	devServer: {
+		proxy: {
+			'^/mqtt': {
+				target: 'ws://localhost:9001',
+				ws: true,
+			},
+		},
+	},
 	configureWebpack: {
 		resolve: {
 			fallback: {


### PR DESCRIPTION
- change websocket endpoint to `mqtt` to avoid conflict with webpack dev server
- add proxy to webpack dev server for our mqtt websocket
- fallback to standard ports if location.port is empty