### PR TITLE
rename dev server websocket endpoint

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@ export default {
 				port:
 					parseInt(location.port) ||
 					(location.protocol == "https:" ? 443 : 80),
-				endpoint: "/mqtt",
+				endpoint: "/ws",
 				connectTimeout: 4000,
 				reconnectPeriod: 4000,
 			},

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,8 +6,15 @@ module.exports = {
 		sourceMap: true,
 	},
 	devServer: {
+		webSocketServer: {
+			options: {
+				// change default path "/ws" to avoid collision
+				// with openWB websocket for mqtt
+				path: "/devserver",
+			},
+		},
 		proxy: {
-			'^/mqtt': {
+			'^/ws': {
 				target: 'ws://localhost:9001',
 				ws: true,
 			},


### PR DESCRIPTION
Moved development websocket from `/ws` to `/devserver`. This allows us to use standard path `/ws` again for mqtt websocket.