### PR TITLE
text/number input empty value

### DIFF
--- a/src/components/OpenwbBaseNumberInput.vue
+++ b/src/components/OpenwbBaseNumberInput.vue
@@ -61,6 +61,7 @@ export default {
 		title: String,
 		modelValue: { type: Number },
 		unit: String,
+		emptyValue: { required: false, default: null },
 	},
 	emits: ["update:modelValue"],
 	data() {
@@ -74,6 +75,9 @@ export default {
 				return this.modelValue;
 			},
 			set(newValue) {
+				if (isNaN(newValue) || typeof newValue != "number") {
+					newValue = this.emptyValue;
+				}
 				this.$emit("update:modelValue", newValue);
 			},
 		},

--- a/src/components/OpenwbBaseTextInput.vue
+++ b/src/components/OpenwbBaseTextInput.vue
@@ -225,6 +225,7 @@ export default {
 		},
 		pattern: String,
 		unit: String,
+		emptyValue: { required: false, default: null },
 	},
 	emits: ["update:modelValue"],
 	data() {
@@ -265,6 +266,10 @@ export default {
 						this.tempValue = newValue;
 					}
 				} else {
+					if (newValue == "") {
+						console.log(this.emptyValue);
+						newValue = this.emptyValue;
+					}
 					this.$emit("update:modelValue", newValue);
 				}
 			},


### PR DESCRIPTION
- added parameter to set the "empty" value of text and number inputs
- defaults to `null`