### PR TITLE
restructure display and web theme configuration

### DIFF
--- a/src/components/display_themes/OpenwbDisplayThemeFallback.vue
+++ b/src/components/display_themes/OpenwbDisplayThemeFallback.vue
@@ -1,23 +1,23 @@
 <template>
 	<div class="display-theme-fallback">
 		<openwb-base-alert
-			v-if="Object.keys(configuration).length == 0"
+			v-if="Object.keys(displayTheme.configuration).length == 0"
 			subtype="info"
 		>
-			Das Display-Theme "{{ displayThemeType }}" bietet keine
+			Das Display-Theme "{{ displayTheme.name }}" bietet keine
 			Einstellungen.
 		</openwb-base-alert>
 		<div v-else>
 			<openwb-base-alert subtype="warning">
 				Es wurde keine Konfigurationsseite für das Display-Theme "{{
-					displayThemeType
+					displayTheme.name
 				}}" gefunden. Die Einstellungen können als JSON direkt
 				bearbeitet werden.
 			</openwb-base-alert>
 			<openwb-base-textarea
 				title="Konfiguration"
 				subtype="json"
-				:model-value="configuration"
+				:model-value="displayTheme.configuration"
 				@update:model-value="
 					updateConfiguration($event, 'configuration')
 				"
@@ -28,7 +28,9 @@
 				</template>
 			</openwb-base-textarea>
 			<openwb-base-alert subtype="info">
-				<pre>{{ JSON.stringify(configuration, undefined, 2) }}</pre>
+				<pre>{{
+					JSON.stringify(displayTheme.configuration, undefined, 2)
+				}}</pre>
 			</openwb-base-alert>
 		</div>
 	</div>
@@ -39,8 +41,7 @@ export default {
 	name: "DisplayThemeFallback",
 	emits: ["update:configuration"],
 	props: {
-		configuration: { type: Object, required: true },
-		displayThemeType: { type: String },
+		displayTheme: { type: Object, required: true },
 	},
 	methods: {
 		updateConfiguration(event, path = undefined) {

--- a/src/components/display_themes/OpenwbDisplayThemeProxy.vue
+++ b/src/components/display_themes/OpenwbDisplayThemeProxy.vue
@@ -1,13 +1,30 @@
 <template>
+	<openwb-base-alert v-if="displayTheme.official" subtype="success">
+		<font-awesome-icon fixed-width :icon="['fas', 'certificate']" />
+		Das ausgewählte Theme wird von openWB gepflegt.
+	</openwb-base-alert>
+	<openwb-base-alert v-else subtype="info">
+		<font-awesome-icon fixed-width :icon="['fas', 'people-group']" />
+		Das ausgewählte Theme wird in unserer Community gepflegt. Rückfragen
+		oder Probleme bitte im Forum diskutieren.
+	</openwb-base-alert>
 	<component
 		:is="myComponent"
-		:configuration="configuration"
-		:displayThemeType="displayThemeType"
+		:displayTheme="displayTheme"
 		@update:configuration="updateConfiguration($event)"
 	/>
 </template>
 
 <script>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import {
+	faPeopleGroup as fasPeopleGroup,
+	faCertificate as fasCertificate,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+library.add(fasPeopleGroup, fasCertificate);
+
 import { defineAsyncComponent } from "vue";
 import OpenwbDisplayThemeFallback from "./OpenwbDisplayThemeFallback.vue";
 
@@ -15,15 +32,17 @@ export default {
 	name: "OpenwbDisplayThemeProxy",
 	emits: ["update:configuration"],
 	props: {
-		displayThemeType: { type: String, required: true },
-		configuration: { type: Object, required: true },
+		displayTheme: { type: Object, required: true },
+	},
+	components: {
+		FontAwesomeIcon,
 	},
 	computed: {
 		myComponent() {
-			console.debug(`loading display theme: ${this.displayThemeType}`);
+			console.debug(`loading display theme: ${this.displayTheme.type}`);
 			return defineAsyncComponent({
 				loader: () =>
-					import(`./${this.displayThemeType}/displayTheme.vue`),
+					import(`./${this.displayTheme.type}/displayTheme.vue`),
 				errorComponent: OpenwbDisplayThemeFallback,
 			});
 		},

--- a/src/components/display_themes/cards/displayTheme.vue
+++ b/src/components/display_themes/cards/displayTheme.vue
@@ -1,8 +1,7 @@
 <template>
 	<div class="display-theme-cards">
 		<openwb-base-heading>
-			Einstellungen für Display Theme Cards
-			<span class="small">(Modul: {{ $options.name }})</span>
+			Einstellungen für Display Theme {{ displayTheme.name }}
 		</openwb-base-heading>
 		<openwb-base-heading>Bediensperre</openwb-base-heading>
 		<openwb-base-button-group-input

--- a/src/components/display_themes/cards/displayTheme.vue
+++ b/src/components/display_themes/cards/displayTheme.vue
@@ -7,7 +7,7 @@
 		<openwb-base-heading>Bediensperre</openwb-base-heading>
 		<openwb-base-button-group-input
 			title="Bedienung sperren"
-			:model-value="configuration.lock_changes"
+			:model-value="displayTheme.configuration.lock_changes"
 			@update:model-value="
 				updateConfiguration($event, 'configuration.lock_changes')
 			"
@@ -25,12 +25,12 @@
 			]"
 		/>
 		<openwb-base-text-input
-			v-if="configuration.lock_changes"
+			v-if="displayTheme.configuration.lock_changes"
 			title="PIN zur Freigabe"
 			subtype="password"
 			required
 			pattern="[0-9]{4,10}"
-			:model-value="configuration.lock_changes_code"
+			:model-value="displayTheme.configuration.lock_changes_code"
 			@update:model-value="
 				updateConfiguration($event, 'configuration.lock_changes_code')
 			"
@@ -42,7 +42,7 @@
 		<openwb-base-heading>Ansicht "Übersicht"</openwb-base-heading>
 		<openwb-base-button-group-input
 			title="Übersicht anzeigen"
-			:model-value="configuration.enable_dashboard_view"
+			:model-value="displayTheme.configuration.enable_dashboard_view"
 			@update:model-value="
 				updateConfiguration(
 					$event,
@@ -63,9 +63,9 @@
 			]"
 		/>
 		<openwb-base-button-group-input
-			v-if="configuration.enable_dashboard_view"
+			v-if="displayTheme.configuration.enable_dashboard_view"
 			title="EVU anzeigen"
-			:model-value="configuration.enable_dashboard_card_grid"
+			:model-value="displayTheme.configuration.enable_dashboard_card_grid"
 			@update:model-value="
 				updateConfiguration(
 					$event,
@@ -86,9 +86,12 @@
 			]"
 		/>
 		<openwb-base-button-group-input
-			v-if="configuration.enable_dashboard_view"
+			v-if="displayTheme.configuration.enable_dashboard_view"
 			title="Hausverbrauch anzeigen"
-			:model-value="configuration.enable_dashboard_card_home_consumption"
+			:model-value="
+				displayTheme.configuration
+					.enable_dashboard_card_home_consumption
+			"
 			@update:model-value="
 				updateConfiguration(
 					$event,
@@ -109,9 +112,11 @@
 			]"
 		/>
 		<openwb-base-button-group-input
-			v-if="configuration.enable_dashboard_view"
+			v-if="displayTheme.configuration.enable_dashboard_view"
 			title="Batteriespeicher anzeigen"
-			:model-value="configuration.enable_dashboard_card_battery_sum"
+			:model-value="
+				displayTheme.configuration.enable_dashboard_card_battery_sum
+			"
 			@update:model-value="
 				updateConfiguration(
 					$event,
@@ -132,9 +137,12 @@
 			]"
 		/>
 		<openwb-base-button-group-input
-			v-if="configuration.enable_dashboard_view"
+			v-if="displayTheme.configuration.enable_dashboard_view"
 			title="Ladepunkte anzeigen"
-			:model-value="configuration.enable_dashboard_card_charge_point_sum"
+			:model-value="
+				displayTheme.configuration
+					.enable_dashboard_card_charge_point_sum
+			"
 			@update:model-value="
 				updateConfiguration(
 					$event,
@@ -155,9 +163,11 @@
 			]"
 		/>
 		<openwb-base-button-group-input
-			v-if="configuration.enable_dashboard_view"
+			v-if="displayTheme.configuration.enable_dashboard_view"
 			title="PV anzeigen"
-			:model-value="configuration.enable_dashboard_card_inverter_sum"
+			:model-value="
+				displayTheme.configuration.enable_dashboard_card_inverter_sum
+			"
 			@update:model-value="
 				updateConfiguration(
 					$event,
@@ -180,7 +190,7 @@
 		<openwb-base-heading>Ansicht "Ladepunkte"</openwb-base-heading>
 		<openwb-base-button-group-input
 			title="Ladepunkte anzeigen"
-			:model-value="configuration.enable_charge_points_view"
+			:model-value="displayTheme.configuration.enable_charge_points_view"
 			@update:model-value="
 				updateConfiguration(
 					$event,
@@ -203,7 +213,7 @@
 		<openwb-base-heading>Ansicht "Status"</openwb-base-heading>
 		<openwb-base-button-group-input
 			title="Status anzeigen"
-			:model-value="configuration.enable_status_view"
+			:model-value="displayTheme.configuration.enable_status_view"
 			@update:model-value="
 				updateConfiguration($event, 'configuration.enable_status_view')
 			"
@@ -228,7 +238,7 @@ export default {
 	name: "DisplayThemeCards",
 	emits: ["update:configuration"],
 	props: {
-		configuration: { type: Object, required: true },
+		displayTheme: { type: Object, required: true },
 	},
 	methods: {
 		updateConfiguration(event, path = undefined) {

--- a/src/components/web_themes/OpenwbWebThemeFallback.vue
+++ b/src/components/web_themes/OpenwbWebThemeFallback.vue
@@ -1,22 +1,22 @@
 <template>
 	<div class="web-theme-fallback">
 		<openwb-base-alert
-			v-if="Object.keys(configuration).length == 0"
+			v-if="Object.keys(webTheme.configuration).length == 0"
 			subtype="info"
 		>
-			Das Web Theme "{{ webThemeType }}" bietet keine Einstellungen.
+			Das Web Theme "{{ webTheme.name }}" bietet keine Einstellungen.
 		</openwb-base-alert>
 		<div v-else>
 			<openwb-base-alert subtype="warning">
 				Es wurde keine Konfigurationsseite für das Web Theme "{{
-					webThemeType
+					webTheme.name
 				}}" gefunden. Die Einstellungen können als JSON direkt
 				bearbeitet werden.
 			</openwb-base-alert>
 			<openwb-base-textarea
 				title="Theme Konfiguration"
 				subtype="json"
-				:model-value="configuration"
+				:model-value="webTheme.configuration"
 				@update:model-value="
 					updateConfiguration($event, 'configuration')
 				"
@@ -27,7 +27,9 @@
 				</template>
 			</openwb-base-textarea>
 			<openwb-base-alert subtype="info">
-				<pre>{{ JSON.stringify(configuration, undefined, 2) }}</pre>
+				<pre>{{
+					JSON.stringify(webTheme.configuration, undefined, 2)
+				}}</pre>
 			</openwb-base-alert>
 		</div>
 	</div>
@@ -38,8 +40,7 @@ export default {
 	name: "WebThemeFallback",
 	emits: ["update:configuration"],
 	props: {
-		configuration: { type: Object, required: true },
-		webThemeType: { type: String },
+		webTheme: { type: Object, required: true },
 	},
 	methods: {
 		updateConfiguration(event, path = undefined) {

--- a/src/components/web_themes/OpenwbWebThemeProxy.vue
+++ b/src/components/web_themes/OpenwbWebThemeProxy.vue
@@ -1,13 +1,30 @@
 <template>
+	<openwb-base-alert v-if="webTheme.official" subtype="success">
+		<font-awesome-icon fixed-width :icon="['fas', 'certificate']" />
+		Das ausgewählte Theme wird von openWB gepflegt.
+	</openwb-base-alert>
+	<openwb-base-alert v-else subtype="info">
+		<font-awesome-icon fixed-width :icon="['fas', 'people-group']" />
+		Das ausgewählte Theme wird in unserer Community gepflegt. Rückfragen
+		oder Probleme bitte im Forum diskutieren.
+	</openwb-base-alert>
 	<component
 		:is="myComponent"
-		:configuration="configuration"
-		:webThemeType="webThemeType"
+		:webTheme="webTheme"
 		@update:configuration="updateConfiguration($event)"
 	/>
 </template>
 
 <script>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import {
+	faPeopleGroup as fasPeopleGroup,
+	faCertificate as fasCertificate,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+library.add(fasPeopleGroup, fasCertificate);
+
 import { defineAsyncComponent } from "vue";
 import OpenwbWebThemeFallback from "./OpenwbWebThemeFallback.vue";
 
@@ -15,14 +32,16 @@ export default {
 	name: "OpenwbWebThemeProxy",
 	emits: ["update:configuration"],
 	props: {
-		webThemeType: { type: String, required: true },
-		configuration: { type: Object, required: true },
+		webTheme: { type: Object, required: true },
+	},
+	components: {
+		FontAwesomeIcon,
 	},
 	computed: {
 		myComponent() {
-			console.debug(`loading web theme: ${this.webThemeType}`);
+			console.debug(`loading web theme: ${this.webTheme.name}`);
 			return defineAsyncComponent({
-				loader: () => import(`./${this.webThemeType}/webTheme.vue`),
+				loader: () => import(`./${this.webTheme.type}/webTheme.vue`),
 				errorComponent: OpenwbWebThemeFallback,
 			});
 		},

--- a/src/views/GeneralConfig.vue
+++ b/src/views/GeneralConfig.vue
@@ -477,7 +477,7 @@
 						<openwb-base-select-input
 							class="mb-2"
 							title="Theme"
-							:options="webThemeList"
+							:groups="webThemeGroupList"
 							:model-value="
 								$store.state.mqtt['openWB/general/web_theme']
 									.type
@@ -489,13 +489,8 @@
 								$store.state.mqtt['openWB/general/web_theme']
 									.type
 							"
-							:webThemeType="
+							:webTheme="
 								$store.state.mqtt['openWB/general/web_theme']
-									.type
-							"
-							:configuration="
-								$store.state.mqtt['openWB/general/web_theme']
-									.configuration
 							"
 							@update:configuration="
 								updateConfiguration(
@@ -586,9 +581,25 @@ export default {
 				];
 			},
 		},
+		webThemeGroupList: {
+			get() {
+				let groups = [
+					{ label: "openWB", options: [] },
+					{ label: "Community", options: [] },
+				];
+				this.webThemeList.forEach((theme) => {
+					if (theme.official === true) {
+						groups[0].options.push(theme);
+					} else {
+						groups[1].options.push(theme);
+					}
+				});
+				return groups;
+			},
+		},
 	},
 	methods: {
-		getWebThemeDefaultConfiguration(webThemeType) {
+		getWebThemeDefaults(webThemeType) {
 			const webThemeDefaults = this.webThemeList.find(
 				(element) => element.value == webThemeType
 			);
@@ -599,9 +610,7 @@ export default {
 				)
 			) {
 				return {
-					...JSON.parse(
-						JSON.stringify(webThemeDefaults.defaults.configuration)
-					),
+					...JSON.parse(JSON.stringify(webThemeDefaults.defaults)),
 				};
 			}
 			console.warn(
@@ -611,11 +620,9 @@ export default {
 			return {};
 		},
 		updateSelectedWebTheme($event) {
-			this.updateState("openWB/general/web_theme", $event, "type");
 			this.updateState(
 				"openWB/general/web_theme",
-				this.getWebThemeDefaultConfiguration($event),
-				"configuration"
+				this.getWebThemeDefaults($event)
 			);
 		},
 		updateConfiguration(key, event) {

--- a/src/views/OptionalComponents.vue
+++ b/src/views/OptionalComponents.vue
@@ -1310,7 +1310,7 @@
 						<openwb-base-select-input
 							class="mb-2"
 							title="Theme des Displays"
-							:options="displayThemeList"
+							:groups="displayThemeGroupList"
 							:model-value="
 								$store.state.mqtt[
 									'openWB/optional/int_display/theme'
@@ -1333,15 +1333,10 @@
 									'openWB/optional/int_display/theme'
 								].type
 							"
-							:displayThemeType="
+							:displayTheme="
 								$store.state.mqtt[
 									'openWB/optional/int_display/theme'
-								].type
-							"
-							:configuration="
-								$store.state.mqtt[
-									'openWB/optional/int_display/theme'
-								].configuration
+								]
 							"
 							@update:configuration="
 								updateConfiguration(
@@ -1485,9 +1480,25 @@ export default {
 				];
 			},
 		},
+		displayThemeGroupList: {
+			get() {
+				let groups = [
+					{ label: "openWB", options: [] },
+					{ label: "Community", options: [] },
+				];
+				this.displayThemeList.forEach((theme) => {
+					if (theme.official === true) {
+						groups[0].options.push(theme);
+					} else {
+						groups[1].options.push(theme);
+					}
+				});
+				return groups;
+			},
+		},
 	},
 	methods: {
-		getDisplayThemeDefaultConfiguration(displayThemeType) {
+		getDisplayThemeDefaults(displayThemeType) {
 			const displayThemeDefaults = this.displayThemeList.find(
 				(element) => element.value == displayThemeType
 			);
@@ -1500,7 +1511,7 @@ export default {
 				return {
 					...JSON.parse(
 						JSON.stringify(
-							displayThemeDefaults.defaults.configuration
+							displayThemeDefaults.defaults
 						)
 					),
 				};
@@ -1514,13 +1525,7 @@ export default {
 		updateSelectedDisplayTheme($event) {
 			this.updateState(
 				"openWB/optional/int_display/theme",
-				$event,
-				"type"
-			);
-			this.updateState(
-				"openWB/optional/int_display/theme",
-				this.getDisplayThemeDefaultConfiguration($event),
-				"configuration"
+				this.getDisplayThemeDefaults($event)
 			);
 		},
 		updateConfiguration(key, event) {


### PR DESCRIPTION
- add "official" flag handling, requires https://github.com/openWB/core/pull/1245
  - group select elements by flag
  - display hint for selected theme
- pass complete theme object to proxy and theme specific configuration files