### PR TITLE
Rename rfid

### DIFF
--- a/src/views/ChargeLog.vue
+++ b/src/views/ChargeLog.vue
@@ -78,7 +78,7 @@
 						</template>
 					</openwb-base-select-input>
 					<openwb-base-array-input
-						title="RFID-Tags"
+						title="ID-Tags"
 						v-model="chargeLogRequestData.filter.vehicle.tag"
 						@update:model-value="requestChargeLog()"
 					>
@@ -291,7 +291,7 @@ export default {
 						},
 					},
 					{
-						label: "RFID-Tag",
+						label: "ID-Tag",
 						field: "vehicle_rfid",
 						sortable: true,
 					},
@@ -443,7 +443,7 @@ export default {
 						"Fahrzeug",
 						"Lademodus",
 						"Priorität",
-						"RFID-Tag",
+						"ID-Tag",
 						"Beginn",
 						"Ende",
 						"Zeitstempel Beginn",

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -497,8 +497,10 @@
 							>
 								<template #help>
 									An allen Ladepunkten, denen dieses
-									Ladepunkt-Profil zugeordnet ist, können die
-									hier eingetragenen ID-Tags verwendet werden.<br />
+									Ladepunkt-Profil zugeordnet ist, werden die
+									hier eingetragenen ID-Tags zur Freischaltung
+									verwendet.
+									<br />
 									<span
 										v-html="$store.state.text.rfidWiki"
 									></span>

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -469,7 +469,7 @@
 								Zugangskontrolle
 							</openwb-base-heading>
 							<openwb-base-button-group-input
-								title="Freigabe mit RFID"
+								title="Freigabe durch ID-Tags"
 								:buttons="[
 									{ buttonValue: false, text: 'Nein' },
 									{ buttonValue: true, text: 'Ja' },
@@ -484,8 +484,8 @@
 								"
 							/>
 							<openwb-base-array-input
-								title="Zugeordnete Tags"
-								noElementsMessage="Keine Tags zugeordnet."
+								title="Zugeordnete ID-Tags"
+								noElementsMessage="Keine ID-Tags zugeordnet."
 								:model-value="chargePointTemplate.valid_tags"
 								@update:model-value="
 									updateState(
@@ -498,7 +498,7 @@
 								<template #help>
 									An allen Ladepunkten, denen dieses
 									Ladepunkt-Profil zugeordnet ist, können die
-									hier eingetragenen Tags verwendet werden.<br />
+									hier eingetragenen ID-Tags verwendet werden.<br />
 									<span
 										v-html="$store.state.text.rfidWiki"
 									></span>
@@ -506,8 +506,8 @@
 							</openwb-base-array-input>
 							<hr />
 						</div>
-						<openwb-base-heading
-							>Angaben zum konfigurierten Ladestrom der openWB
+						<openwb-base-heading>
+							Angaben zum konfigurierten Ladestrom der openWB
 						</openwb-base-heading>
 						<openwb-base-alert subtype="info">
 							Hier werden die maximalen Ladeströme entsprechend
@@ -1089,7 +1089,7 @@ export default {
 		removeChargePointTemplate(chargePointTemplateIndex, event) {
 			this.showChargePointTemplateModal = false;
 			if (event == "confirm") {
-				console.info(
+				console.debug(
 					"request removal of chargePoint template '" +
 						chargePointTemplateIndex +
 						"'"
@@ -1134,7 +1134,7 @@ export default {
 		) {
 			this.showChargePointTemplateAutolockPlanModal = false;
 			if (event == "confirm") {
-				console.info(
+				console.debug(
 					"request removal of chargePoint template '" +
 						chargePointTemplateIndex +
 						"' autolock plan '" +

--- a/src/views/OptionalComponents.vue
+++ b/src/views/OptionalComponents.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="optionalComponents">
 		<form name="optionalComponentsForm">
-			<openwb-base-card title="RFID">
+			<openwb-base-card title="Identifikation von Fahrzeugen">
 				<openwb-base-button-group-input
-					title="RFID aktivieren"
+					title="Identifikation aktivieren"
 					:model-value="
 						$store.state.mqtt['openWB/optional/rfid/active']
 					"
@@ -24,9 +24,12 @@
 					]"
 				>
 					<template #help>
-						Dies bedingt das Vorhandensein eines RFID-Readers in
-						deiner openWB. Bitte prüfe zuerst die
-						Hardwareausstattung deiner openWB (z.B. Lieferschein).
+						Die Identifikation von Fahrzeugen kann auf mehreren Wegen erfolgen:
+						<ul>
+							<li>Über einen in der openWB verbauten RFID-Reader (optional, z.B. anhand des Lieferscheins prüfen).</li>
+							<li>Durch die automatische Erkennung an einer openWB Pro (muss in den Einstellungen aktiviert werden).</li>
+							<!-- <li>Durch manuelle Eingabe einer ID am Display einer openWB.</li> ToDo! -->
+						</ul>
 					</template>
 				</openwb-base-button-group-input>
 				<div
@@ -36,16 +39,16 @@
 					"
 				>
 					<openwb-base-alert subtype="info">
-						Die RFID-Tags, die an dem jeweiligen Ladepunkt gültig
+						Die ID-Tags, die an dem jeweiligen Ladepunkt gültig
 						sind, müssen in dem Ladepunkt-Profil hinterlegt werden.
-						Der RFID-Tag muss in den Einstellungen des Fahrzeugs
-						diesem zugeordnet werden.<br />
-						Es kann zuerst angesteckt und dann der RFID-Tag gescannt
-						werden oder zuerst der RFID-Tag gescannt werden. Dann
-						muss innerhalb von 5 Minuten ein Auto angesteckt werden,
-						sonst wird der RFID-Tag verworfen. Das Auto wird erst
+						Die ID-Tags müssen auch in den Einstellungen der Fahrzeuge
+						diesen zugeordnet werden.<br />
+						Es kann zuerst das Fahrzeug angesteckt und dann der ID-Tag erfasst
+						werden oder anders herum. Im letzten Fall
+						muss innerhalb von 5 Minuten ein Fahrzeug angesteckt werden,
+						sonst wird der ID-Tag verworfen. Das Fahrzeug wird erst
 						nach dem Anstecken zugeordnet.<br />
-						<span v-html="$store.state.text.rfidWiki"></span>
+						<span v-html="$store.state.text.rfidWiki" />
 					</openwb-base-alert>
 				</div>
 			</openwb-base-card>

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -209,7 +209,7 @@
 							"
 						>
 							<openwb-base-array-input
-								title="Zugeordnete Tags"
+								title="Zugeordnete ID-Tags"
 								:model-value="
 									$store.state.mqtt[
 										'openWB/vehicle/' +
@@ -227,13 +227,11 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
-								Der/die RFID-Tag(s) müssen in dem
+								Die ID-Tags müssen auch in den
 								Ladepunkt-Profil eingetragen werden, um
-								zuzuordnen, an welchem Ladepunkt die Tags
+								zuzuordnen, an welchen Ladepunkten die ID-Tags
 								verwendet werden dürfen.<br />
-								<span
-									v-html="$store.state.text.rfidWiki"
-								></span>
+								<span v-html="$store.state.text.rfidWiki" />
 							</openwb-base-alert>
 							<hr />
 						</div>

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -227,10 +227,10 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
-								Die ID-Tags müssen auch in den
-								Ladepunkt-Profil eingetragen werden, um
-								zuzuordnen, an welchen Ladepunkten die ID-Tags
-								verwendet werden dürfen.<br />
+								Die ID-Tags müssen auch in den Ladepunkt-Profil
+								eingetragen werden, um zuzuordnen, an welchen
+								Ladepunkten die ID-Tags verwendet werden
+								dürfen.<br />
 								<span v-html="$store.state.text.rfidWiki" />
 							</openwb-base-alert>
 							<hr />


### PR DESCRIPTION
- change wording from "RFID" to "ID-Tag", because we have different sources for vehicle identification, not only rfid
- add textfield with detected ID-Tags for easier setup