### PR TITLE
Rfid redesign

### DIFF
--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -457,14 +457,13 @@
 								Das Standard-Profil kann nicht umbenannt werden.
 							</template>
 						</openwb-base-text-input>
-						<hr />
+
 						<div
 							v-if="
-								$store.state.mqtt[
-									'openWB/optional/rfid/active'
-								] === true
+								$store.state.mqtt['openWB/optional/rfid/active']
 							"
 						>
+							<hr />
 							<openwb-base-heading>
 								Zugangskontrolle
 							</openwb-base-heading>
@@ -487,7 +486,9 @@
 								<openwb-base-array-input
 									title="Zugeordnete ID-Tags"
 									noElementsMessage="Keine ID-Tags zugeordnet."
-									:model-value="chargePointTemplate.valid_tags"
+									:model-value="
+										chargePointTemplate.valid_tags
+									"
 									@update:model-value="
 										updateState(
 											chargePointTemplateKey,
@@ -497,13 +498,13 @@
 									"
 								>
 									<template #help>
-										Wenn hier Tags eingetragen werden, können
-										nur die eingetragenen Tags zur
+										Wenn hier Tags eingetragen werden,
+										können nur die eingetragenen Tags zur
 										Fahrzeug-Zuordnung genutzt werden. Sind
 										keine Tags eingetragen, wird nur die
-										Zuordnung zum Fahrzeug geprüft. In diesem
-										Fall können alle Fahrzeuge diesen Ladepunkt
-										nutzen.
+										Zuordnung zum Fahrzeug geprüft. In
+										diesem Fall können alle Fahrzeuge diesen
+										Ladepunkt nutzen.
 										<br />
 										<span
 											v-html="$store.state.text.rfidWiki"

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -483,33 +483,35 @@
 									)
 								"
 							/>
-							<openwb-base-array-input
-								title="Zugeordnete ID-Tags"
-								noElementsMessage="Keine ID-Tags zugeordnet."
-								:model-value="chargePointTemplate.valid_tags"
-								@update:model-value="
-									updateState(
-										chargePointTemplateKey,
-										$event,
-										'valid_tags',
-									)
-								"
-							>
-								<template #help>
-									Wenn hier Tags eingetragen werden, können
-									nur die eingetragenen Tags zur
-									Fahrzeug-Zuordnung genutzt werden. Sind
-									keine Tags eingetragen, wird nur die
-									Zuordnung zum Fahrzeug geprüft. In diesem
-									Fall können alle Fahrzeuge diesen Ladepunkt
-									nutzen.
-									<br />
-									<span
-										v-html="$store.state.text.rfidWiki"
-									></span>
-								</template>
-							</openwb-base-array-input>
-							<hr />
+							<div v-if="chargePointTemplate.rfid_enabling">
+								<openwb-base-array-input
+									title="Zugeordnete ID-Tags"
+									noElementsMessage="Keine ID-Tags zugeordnet."
+									:model-value="chargePointTemplate.valid_tags"
+									@update:model-value="
+										updateState(
+											chargePointTemplateKey,
+											$event,
+											'valid_tags',
+										)
+									"
+								>
+									<template #help>
+										Wenn hier Tags eingetragen werden, können
+										nur die eingetragenen Tags zur
+										Fahrzeug-Zuordnung genutzt werden. Sind
+										keine Tags eingetragen, wird nur die
+										Zuordnung zum Fahrzeug geprüft. In diesem
+										Fall können alle Fahrzeuge diesen Ladepunkt
+										nutzen.
+										<br />
+										<span
+											v-html="$store.state.text.rfidWiki"
+										></span>
+									</template>
+								</openwb-base-array-input>
+								<hr />
+							</div>
 						</div>
 						<openwb-base-heading>
 							Angaben zum konfigurierten Ladestrom der openWB

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -227,7 +227,9 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
-								Die ID-Tags müssen auch in den Ladepunkt-Profil
+								Insofern Freigabe durch ID-Tags im Ladepunkt-Profil
+								aktiviert wurde, müssen die den Fahrzeugen zugeordnete 
+								ID-Tags auch in das entsprechende Ladepunkt-Profil
 								eingetragen werden, um zuzuordnen, an welchen
 								Ladepunkten die ID-Tags verwendet werden
 								dürfen.<br />


### PR DESCRIPTION
Hide field Access (Zugangskontrolle) in charging point loading profile if RFID is not set to active in optional hardware and hide field registered ID-tags if rfid is not enabled