### PR TITLE
Eindeutige Bezeichnung für Fahrzeug-SoC, SolarEdge-Bezeichner, etc

### DIFF
--- a/src/components/devices/good_we/device.vue
+++ b/src/components/devices/good_we/device.vue
@@ -4,6 +4,11 @@
 			Einstellungen für GoodWe
 			<span class="small">(Modul: {{ $options.name }})</span>
 		</openwb-base-heading>
+		<openwb-base-alert subtype="info">
+			GoodWe-Wechselrichter verfügen über 2 Dongel: WiFi und Wifi/Lan. Die
+			Einbindung über dieses Modul ist nur mit dem Wifi/Lan-Dongle
+			möglich.
+		</openwb-base-alert>
 		<openwb-base-text-input
 			title="IP oder Hostname"
 			subtype="host"

--- a/src/components/devices/solaredge/bat.vue
+++ b/src/components/devices/solaredge/bat.vue
@@ -5,7 +5,7 @@
 			<span class="small">(Modul: {{ $options.name }})</span>
 		</openwb-base-heading>
 		<openwb-base-number-input
-			title="Modbus ID"
+			title="SolarEdge-Geräte-ID"
 			required
 			:model-value="configuration.modbus_id"
 			min="1"

--- a/src/components/devices/solaredge/counter.vue
+++ b/src/components/devices/solaredge/counter.vue
@@ -10,7 +10,7 @@
 			Wechselrichter konfiguriert sein.
 		</openwb-base-alert>
 		<openwb-base-number-input
-			title="Modbus ID"
+			title="SolarEdge-Geräte-ID"
 			required
 			:model-value="configuration.modbus_id"
 			min="1"
@@ -20,7 +20,7 @@
 			"
 		/>
 		<openwb-base-number-input
-			title="Meter ID"
+			title="SolarEdge-Meter-ID"
 			:model-value="configuration.meter_id"
 			min="1"
 			max="255"

--- a/src/components/devices/solaredge/external_inverter.vue
+++ b/src/components/devices/solaredge/external_inverter.vue
@@ -12,7 +12,7 @@
 			konfiguriert sein.
 		</openwb-base-alert>
 		<openwb-base-number-input
-			title="Modbus ID"
+			title="SolarEdge-Geräte-ID"
 			required
 			:model-value="configuration.modbus_id"
 			min="1"
@@ -22,7 +22,7 @@
 			"
 		/>
 		<openwb-base-number-input
-			title="Meter ID"
+			title="SolarEdge-Meter-ID"
 			:model-value="configuration.meter_id"
 			min="1"
 			max="255"

--- a/src/components/devices/solaredge/inverter.vue
+++ b/src/components/devices/solaredge/inverter.vue
@@ -5,7 +5,7 @@
 			<span class="small">(Modul: {{ $options.name }})</span>
 		</openwb-base-heading>
 		<openwb-base-number-input
-			title="Modbus ID"
+			title="SolarEdge-Geräte-ID"
 			required
 			:model-value="configuration.modbus_id"
 			min="1"

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -231,26 +231,9 @@
 						<openwb-base-button-group-input
 							title="Phase 1 des Ladekabels"
 							:buttons="[
-								{
-									buttonValue: 0,
-									text: 'unbekannt',
-									class: 'btn-outline-danger',
-								},
-								{
-									buttonValue: 1,
-									text: 'EVU L1',
-									class: 'btn-outline-success',
-								},
-								{
-									buttonValue: 2,
-									text: 'EVU L2',
-									class: 'btn-outline-success',
-								},
-								{
-									buttonValue: 3,
-									text: 'EVU L3',
-									class: 'btn-outline-success',
-								},
+								{ buttonValue: 1, text: 'EVU L1' },
+								{ buttonValue: 2, text: 'EVU L2' },
+								{ buttonValue: 3, text: 'EVU L3' },
 							]"
 							:model-value="installedChargePoint.phase_1"
 							@update:model-value="

--- a/src/views/DataManagement.vue
+++ b/src/views/DataManagement.vue
@@ -43,7 +43,10 @@
 						erstellte Datei über den Link in der Benachrichtigung
 						oder
 						<a href="/openWB/data/backup/" target="_blank">hier</a>
-						heruntergeladen werden.
+						heruntergeladen werden. Beim Herunterladen bitte darauf
+						achten, dass die Datei mit der Endung .tar.gz
+						gespeichert wird. Ggf das automatische Entpacken des
+						Browsers deaktivieren.
 					</openwb-base-alert>
 					<div class="row justify-content-center">
 						<div
@@ -824,6 +827,10 @@ export default {
 		uploadFile(target, selectedFile, successMessage) {
 			return new Promise((resolve) => {
 				if (selectedFile !== undefined) {
+					this.$root.postClientMessage(
+						"Hochladen der Datei gestartet.",
+						"info",
+					);
 					let formData = new FormData();
 					formData.append("file", selectedFile);
 					formData.append("target", target);

--- a/src/views/GeneralConfig.vue
+++ b/src/views/GeneralConfig.vue
@@ -249,61 +249,61 @@
 							</ul>
 						</template>
 					</openwb-base-button-group-input> -->
-				</div>
-				<hr />
-				<openwb-base-heading class="mt-0">
-					Steuerbare Verbrauchseinrichtung
-				</openwb-base-heading>
-				<openwb-base-alert sub_type="info">
-					Aktuell unterstützt openWB die eingehende Steuerung als
-					"Steuerbare Verbrauchseinrichtung" nur über potentialfreie
-					Kontakte (Rundsteuerempfänger, RSE). Ebenfalls können
-					derzeit bei Auslösung des RSE nur alle Ladevorgänge komplett
-					beendet werden. Die Unterstützung von "Dimmung" im Sinne von
-					§14a EnWG wird umgesetzt, sobald wir weitere Informationen
-					von den Netzbetreibern erhalten, wie die Ansteuerung
-					technisch umgesetzt wird.
-				</openwb-base-alert>
-				<openwb-base-select-input
-					class="mb-2"
-					title="Anbindung RSE-Kontakt"
-					:options="rippleControlReceiverList"
-					:model-value="
-						$store.state.mqtt[
-							'openWB/general/ripple_control_receiver/module'
-						]
-							? $store.state.mqtt[
-									'openWB/general/ripple_control_receiver/module'
-								].type
-							: ''
-					"
-					@update:model-value="
-						updateSelectedRippleControlReceiverModule($event)
-					"
-				/>
-				<div
-					v-if="
-						$store.state.mqtt[
-							'openWB/general/ripple_control_receiver/module'
-						] &&
-						$store.state.mqtt[
-							'openWB/general/ripple_control_receiver/module'
-						].type
-					"
-				>
-					<openwb-ripple-control-receiver-proxy
-						:rippleControlReceiver="
+					<hr />
+					<openwb-base-heading class="mt-0">
+						Steuerbare Verbrauchseinrichtung
+					</openwb-base-heading>
+					<openwb-base-alert sub_type="info">
+						Aktuell unterstützt openWB die eingehende Steuerung als
+						"Steuerbare Verbrauchseinrichtung" nur über
+						potentialfreie Kontakte (Rundsteuerempfänger, RSE).
+						Ebenfalls können derzeit bei Auslösung des RSE nur alle
+						Ladevorgänge komplett beendet werden. Die Unterstützung
+						von "Dimmung" im Sinne von §14a EnWG wird umgesetzt,
+						sobald wir weitere Informationen von den Netzbetreibern
+						erhalten, wie die Ansteuerung technisch umgesetzt wird.
+					</openwb-base-alert>
+					<openwb-base-select-input
+						class="mb-2"
+						title="Anbindung RSE-Kontakt"
+						:options="rippleControlReceiverList"
+						:model-value="
 							$store.state.mqtt[
 								'openWB/general/ripple_control_receiver/module'
 							]
+								? $store.state.mqtt[
+										'openWB/general/ripple_control_receiver/module'
+									].type
+								: ''
 						"
-						@update:configuration="
-							updateConfiguration(
-								'openWB/general/ripple_control_receiver/module',
-								$event,
-							)
+						@update:model-value="
+							updateSelectedRippleControlReceiverModule($event)
 						"
 					/>
+					<div
+						v-if="
+							$store.state.mqtt[
+								'openWB/general/ripple_control_receiver/module'
+							] &&
+							$store.state.mqtt[
+								'openWB/general/ripple_control_receiver/module'
+							].type
+						"
+					>
+						<openwb-ripple-control-receiver-proxy
+							:rippleControlReceiver="
+								$store.state.mqtt[
+									'openWB/general/ripple_control_receiver/module'
+								]
+							"
+							@update:configuration="
+								updateConfiguration(
+									'openWB/general/ripple_control_receiver/module',
+									$event,
+								)
+							"
+						/>
+					</div>
 				</div>
 			</openwb-base-card>
 			<!-- <openwb-base-card title="Benachrichtigungen">

--- a/src/views/LoadManagementConfig.vue
+++ b/src/views/LoadManagementConfig.vue
@@ -110,7 +110,10 @@
 					<openwb-base-alert subtype="info">
 						Die maximale Leistung wird nur für den EVU-Zähler
 						berücksichtigt. Bei Zwischenzählern begrenzt das
-						Lastmanagement rein anhand der maximalen Phasenströme.
+						Lastmanagement rein anhand der maximalen
+						Phasenströme.<br />
+						Überlicherweise sind Hausanschlüsse mit 24kW und 3*35A
+						bzw. 43kW und 3*63A abgesichert.
 					</openwb-base-alert>
 					<openwb-base-card
 						v-for="counter in counterConfigs"

--- a/src/views/OptionalComponents.vue
+++ b/src/views/OptionalComponents.vue
@@ -2,75 +2,84 @@
 	<div class="optionalComponents">
 		<form name="optionalComponentsForm">
 			<openwb-base-card title="Identifikation von Fahrzeugen">
-				<openwb-base-button-group-input
-					title="Identifikation aktivieren"
-					:model-value="
-						$store.state.mqtt['openWB/optional/rfid/active']
-					"
-					@update:model-value="
-						updateState('openWB/optional/rfid/active', $event)
-					"
-					:buttons="[
-						{
-							buttonValue: false,
-							text: 'Aus',
-							class: 'btn-outline-danger',
-						},
-						{
-							buttonValue: true,
-							text: 'An',
-							class: 'btn-outline-success',
-						},
-					]"
-				>
-					<template #help>
-						Die Identifikation von Fahrzeugen kann auf mehreren
-						Wegen erfolgen:
-						<ul>
-							<li>
-								Über einen in der openWB verbauten RFID-Reader
-								(optional, z.B. anhand des Lieferscheins
-								prüfen).
-							</li>
-							<li>
-								Durch die automatische Erkennung an einer openWB
-								Pro (muss in den Einstellungen aktiviert
-								werden).
-							</li>
-							<li>
-								Durch manuelle Eingabe einer ID am Display einer
-								openWB.
-							</li>
-						</ul>
-					</template>
-				</openwb-base-button-group-input>
-				<div
-					v-if="
-						$store.state.mqtt['openWB/optional/rfid/active'] ===
-						true
-					"
-				>
-					<openwb-base-alert subtype="info" class="mb-1">
-						Die ID-Tags müssen in den Einstellungen der Fahrzeuge
-						diesen zugeordnet werden.<br />
-						Es kann zuerst das Fahrzeug angesteckt und dann der
-						ID-Tag erfasst werden oder anders herum. Im letzten Fall
-						muss innerhalb von 5 Minuten ein Fahrzeug angesteckt
-						werden, sonst wird der ID-Tag verworfen. Das Fahrzeug
-						wird erst nach dem Anstecken zugeordnet.<br />
-						<span v-html="$store.state.text.rfidWiki" />
+				<div v-if="$store.state.mqtt['openWB/general/extern'] === true">
+					<openwb-base-alert subtype="info">
+						Weitere Einstellungen sind nicht verfügbar, solange sich
+						diese openWB im Steuerungsmodus "secondary" befindet.
 					</openwb-base-alert>
-					<openwb-base-textarea
-						title="Erkannte ID-Tags"
-						readonly
-						disabled
-						:model-value="idTagList.join('\n')"
+				</div>
+				<div v-else>
+					<openwb-base-button-group-input
+						title="Identifikation aktivieren"
+						:model-value="
+							$store.state.mqtt['openWB/optional/rfid/active']
+						"
+						@update:model-value="
+							updateState('openWB/optional/rfid/active', $event)
+						"
+						:buttons="[
+							{
+								buttonValue: false,
+								text: 'Aus',
+								class: 'btn-outline-danger',
+							},
+							{
+								buttonValue: true,
+								text: 'An',
+								class: 'btn-outline-success',
+							},
+						]"
 					>
 						<template #help>
-							Solange diese Seite geöffnet ist, werden alle
-							erfassten ID-Tags in dieser Liste aufgeführt.
+							Die Identifikation von Fahrzeugen kann auf mehreren
+							Wegen erfolgen:
+							<ul>
+								<li>
+									Über einen in der openWB verbauten
+									RFID-Reader (optional, z.B. anhand des
+									Lieferscheins prüfen).
+								</li>
+								<li>
+									Durch die automatische Erkennung an einer
+									openWB Pro (muss in den Einstellungen
+									aktiviert werden).
+								</li>
+								<li>
+									Durch manuelle Eingabe einer ID am Display
+									einer openWB.
+								</li>
+							</ul>
 						</template>
-					</openwb-base-textarea>
+					</openwb-base-button-group-input>
+					<div
+						v-if="
+							$store.state.mqtt['openWB/optional/rfid/active'] ===
+							true
+						"
+					>
+						<openwb-base-alert subtype="info" class="mb-1">
+							Die ID-Tags müssen in den Einstellungen der
+							Fahrzeuge diesen zugeordnet werden.<br />
+							Es kann zuerst das Fahrzeug angesteckt und dann der
+							ID-Tag erfasst werden oder anders herum. Im letzten
+							Fall muss innerhalb von 5 Minuten ein Fahrzeug
+							angesteckt werden, sonst wird der ID-Tag verworfen.
+							Das Fahrzeug wird erst nach dem Anstecken
+							zugeordnet.<br />
+							<span v-html="$store.state.text.rfidWiki" />
+						</openwb-base-alert>
+						<openwb-base-textarea
+							title="Erkannte ID-Tags"
+							readonly
+							disabled
+							:model-value="idTagList.join('\n')"
+						>
+							<template #help>
+								Solange diese Seite geöffnet ist, werden alle
+								erfassten ID-Tags in dieser Liste aufgeführt.
+							</template>
+						</openwb-base-textarea>
+					</div>
 				</div>
 			</openwb-base-card>
 			<!-- <openwb-base-card title="LED-Ausgänge">
@@ -1067,8 +1076,10 @@
 							Nach einer Änderung ist ein Neustart
 							erforderlich!<br />
 							Diese Einstellung erfordert ein Raspberry Pi
-							Display. Anzeigen, welche über HDMI angeschlossen
-							sind, werden nicht unterstützt.
+							Display. Für eine openWB series2 mit integriertem
+							Display muss 0° ausgewählt werden, für eine
+							Standalone mit Display 180°. Anzeigen, welche über
+							HDMI angeschlossen sind, werden nicht unterstützt.
 						</template>
 					</openwb-base-button-group-input>
 					<hr />

--- a/src/views/Support.vue
+++ b/src/views/Support.vue
@@ -83,7 +83,12 @@
 							required
 							subtype="email"
 							v-model="sendDebugData.email"
-						/>
+						>
+							<template #help>
+								Deine E-Mail-Adresse, an die der Support Dir
+								antwortet.
+							</template>
+						</openwb-base-text-input>
 						<openwb-base-text-input
 							title="openWB Seriennummer"
 							required

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -235,7 +235,7 @@
 						</div>
 						<openwb-base-select-input
 							class="mb-2"
-							title="SoC-Modul"
+							title="SoC-Modul des Fahrzeugs"
 							:options="socModuleList"
 							:model-value="
 								$store.state.mqtt[
@@ -1164,7 +1164,7 @@
 								},
 								{
 									buttonValue: 'soc',
-									text: 'SoC',
+									text: 'Fahrzeug-SoC',
 								},
 								{
 									buttonValue: 'amount',
@@ -1192,7 +1192,7 @@
 							</template>
 						</openwb-base-button-group-input>
 						<openwb-base-range-input
-							title="SoC-Limit"
+							title="SoC-Limit für das Fahrzeug"
 							:min="5"
 							:max="100"
 							:step="5"
@@ -1286,7 +1286,7 @@
 							</template>
 						</openwb-base-range-input>
 						<openwb-base-range-input
-							title="SoC-Limit"
+							title="SoC-Limit für das Fahrzeug"
 							:min="0"
 							:max="20"
 							:step="1"
@@ -1341,7 +1341,7 @@
 							</template>
 						</openwb-base-range-input>
 						<openwb-base-range-input
-							title="Mindest-SoC"
+							title="Mindest-SoC für das Fahrzeug"
 							:min="0"
 							:max="19"
 							:step="1"
@@ -1482,8 +1482,8 @@
 								Ist der berechnete Zeitpunkt des Ladestarts noch
 								nicht erreicht, wird mit Überschuss geladen.
 								Auch nach Erreichen des Ziel-SoCs wird mit
-								Überschuss geladen, solange bis das "SoC-Limit"
-								erreicht wird.<br />
+								Überschuss geladen, solange bis das "SoC-Limit
+								für das Fahrzeug" erreicht wird.<br />
 								Kann der Ziel-SoC bzw. die Energiemenge NICHT
 								erreicht werden, z.B. weil das Auto zu spät
 								angesteckt wurde oder das Lastmanagement
@@ -1656,7 +1656,10 @@
 							<openwb-base-button-group-input
 								title="Ziel"
 								:buttons="[
-									{ buttonValue: 'soc', text: 'SoC' },
+									{
+										buttonValue: 'soc',
+										text: 'Fahrzeug-SoC',
+									},
 									{
 										buttonValue: 'amount',
 										text: 'Energie',
@@ -2005,7 +2008,10 @@
 								title="Ziel"
 								:buttons="[
 									{ buttonValue: 'none', text: 'Aus' },
-									{ buttonValue: 'soc', text: 'SoC' },
+									{
+										buttonValue: 'soc',
+										text: 'Fahrzeug-SoC',
+									},
 									{
 										buttonValue: 'amount',
 										text: 'Energie',
@@ -2026,7 +2032,7 @@
 								</template>
 							</openwb-base-button-group-input>
 							<openwb-base-range-input
-								title="Ziel-SoC"
+								title="Ziel-SoC für das Fahrzeug"
 								v-if="plan.limit.selected == 'soc'"
 								:min="5"
 								:max="100"


### PR DESCRIPTION
- [x] Secondaries: RFID Identifikation

Eindeutige Bezeichnung für Fahrzeug-SoC
use SolarEdge names
linting
default values display rotation
übliche Hausanschlüsse
mail
good we
typo
user message upload file
rename setting description Standard-Fahrzeug nach Abstecken
remove obsolet option phase_1 unbekannt
automatisches Entpacken deaktivieren
rfid for secondaries; linting