### PR TITLE
Phasenumschaltung

### DIFF
--- a/src/components/devices/solax/device.vue
+++ b/src/components/devices/solax/device.vue
@@ -24,9 +24,9 @@
 			"
 		>
 			<template #help>
-				Standardmäßig ist der Port 502. Dieser sollte nur geändert werden,
-				wenn der Solax Wechselrichter auf einen anderen Port konfiguriert
-				wurde.
+				Standardmäßig ist der Port 502. Dieser sollte nur geändert
+				werden, wenn der Solax Wechselrichter auf einen anderen Port
+				konfiguriert wurde.
 			</template>
 		</openwb-base-number-input>
 		<openwb-base-number-input

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -487,7 +487,9 @@
 								<openwb-base-array-input
 									title="Zugeordnete ID-Tags"
 									noElementsMessage="Keine ID-Tags zugeordnet."
-									:model-value="chargePointTemplate.valid_tags"
+									:model-value="
+										chargePointTemplate.valid_tags
+									"
 									@update:model-value="
 										updateState(
 											chargePointTemplateKey,
@@ -497,13 +499,13 @@
 									"
 								>
 									<template #help>
-										Wenn hier Tags eingetragen werden, können
-										nur die eingetragenen Tags zur
+										Wenn hier Tags eingetragen werden,
+										können nur die eingetragenen Tags zur
 										Fahrzeug-Zuordnung genutzt werden. Sind
 										keine Tags eingetragen, wird nur die
-										Zuordnung zum Fahrzeug geprüft. In diesem
-										Fall können alle Fahrzeuge diesen Ladepunkt
-										nutzen.
+										Zuordnung zum Fahrzeug geprüft. In
+										diesem Fall können alle Fahrzeuge diesen
+										Ladepunkt nutzen.
 										<br />
 										<span
 											v-html="$store.state.text.rfidWiki"

--- a/src/views/GeneralChargeConfig.vue
+++ b/src/views/GeneralChargeConfig.vue
@@ -311,7 +311,6 @@ export default {
 				"openWB/general/prices/pv",
 				"openWB/optional/et/provider",
 				"openWB/system/configurable/electricity_tariffs",
-				
 			],
 		};
 	},

--- a/src/views/GeneralChargeConfig.vue
+++ b/src/views/GeneralChargeConfig.vue
@@ -118,6 +118,37 @@
 							zurückgesetzt.
 						</template>
 					</openwb-base-button-group-input>
+					<openwb-base-range-input
+						title="Verzögerung automat. Phasenumschaltung"
+						:min="1"
+						:max="15"
+						:step="1"
+						unit="Min."
+						:model-value="
+							$store.state.mqtt[
+								'openWB/general/chargemode_config/pv_charging/phase_switch_delay'
+							]
+						"
+						@update:model-value="
+							updateState(
+								'openWB/general/chargemode_config/pv_charging/phase_switch_delay',
+								$event,
+							)
+						"
+					>
+						<template #help>
+							Um zu viele Umschaltungen zu vermeiden, wird Anhand
+							dieses Wertes definiert, wann die Umschaltung
+							erfolgen soll. Ist für durchgehend x Minuten die
+							Maximalstromstärke erreicht, wird auf mehrphasige
+							Ladung umgestellt. Ist die Ladung nur für ein
+							Intervall unterhalb der Maximalstromstärke, beginnt
+							das Intervall für die Umschaltung erneut. Ist die
+							Ladung im mehrphasigen Modus für 16 - x Minuten auf
+							der Minimalstromstärke, wird wieder auf einphasige
+							Ladung gewechselt.
+						</template>
+					</openwb-base-range-input>
 					<hr />
 					<openwb-base-heading>
 						Berechnung der Ladekosten
@@ -271,6 +302,7 @@ export default {
 		return {
 			mqttTopicsToSubscribe: [
 				"openWB/general/extern",
+				"openWB/general/chargemode_config/pv_charging/phase_switch_delay",
 				"openWB/general/chargemode_config/retry_failed_phase_switches",
 				"openWB/general/chargemode_config/unbalanced_load",
 				"openWB/general/chargemode_config/unbalanced_load_limit",
@@ -279,6 +311,7 @@ export default {
 				"openWB/general/prices/pv",
 				"openWB/optional/et/provider",
 				"openWB/system/configurable/electricity_tariffs",
+				
 			],
 		};
 	},

--- a/src/views/GeneralChargeConfig.vue
+++ b/src/views/GeneralChargeConfig.vue
@@ -126,12 +126,12 @@
 						unit="Min."
 						:model-value="
 							$store.state.mqtt[
-								'openWB/general/chargemode_config/pv_charging/phase_switch_delay'
+								'openWB/general/chargemode_config/phase_switch_delay'
 							]
 						"
 						@update:model-value="
 							updateState(
-								'openWB/general/chargemode_config/pv_charging/phase_switch_delay',
+								'openWB/general/chargemode_config/phase_switch_delay',
 								$event,
 							)
 						"
@@ -302,7 +302,7 @@ export default {
 		return {
 			mqttTopicsToSubscribe: [
 				"openWB/general/extern",
-				"openWB/general/chargemode_config/pv_charging/phase_switch_delay",
+				"openWB/general/chargemode_config/phase_switch_delay",
 				"openWB/general/chargemode_config/retry_failed_phase_switches",
 				"openWB/general/chargemode_config/unbalanced_load",
 				"openWB/general/chargemode_config/unbalanced_load_limit",

--- a/src/views/PVChargeConfig.vue
+++ b/src/views/PVChargeConfig.vue
@@ -368,12 +368,11 @@
 									fixed-width
 									:icon="['fas', 'fa-car-battery']"
 								/>
-								Speicher" wird der gesamte
-								Überschuss in den Speicher geladen. Ist die
-								maximale Ladeleistung des Speichers erreicht und
-								es wird eingespeist, wird dieser Überschuss
-								unter Beachtung der Einschaltschwelle in die
-								Fahrzeuge geladen.
+								Speicher" wird der gesamte Überschuss in den
+								Speicher geladen. Ist die maximale Ladeleistung
+								des Speichers erreicht und es wird eingespeist,
+								wird dieser Überschuss unter Beachtung der
+								Einschaltschwelle in die Fahrzeuge geladen.
 							</p>
 							<p>
 								Bei Auswahl "
@@ -381,13 +380,13 @@
 									fixed-width
 									:icon="['fas', 'fa-battery-half']"
 								/>
-								Mindest-SoC des Speichers" wird der
-								Überschuss bis zum Mindest-SoC in den Speicher
-								geladen. Ist die maximale Ladeleistung des
-								Speichers erreicht und es wird eingespeist, wird
-								dieser Überschuss in die Fahrzeuge geladen. Wird
-								der Mindest-SoC überschritten, wird der
-								Überschuss ins Fahrzeug geladen.
+								Mindest-SoC des Speichers" wird der Überschuss
+								bis zum Mindest-SoC in den Speicher geladen. Ist
+								die maximale Ladeleistung des Speichers erreicht
+								und es wird eingespeist, wird dieser Überschuss
+								in die Fahrzeuge geladen. Wird der Mindest-SoC
+								überschritten, wird der Überschuss ins Fahrzeug
+								geladen.
 							</p>
 						</template>
 					</openwb-base-button-group-input>

--- a/src/views/PVChargeConfig.vue
+++ b/src/views/PVChargeConfig.vue
@@ -289,42 +289,6 @@
 							und drei Phasen (s.g. 1p3p).
 						</template>
 					</openwb-base-button-group-input>
-					<openwb-base-range-input
-						v-if="
-							$store.state.mqtt[
-								'openWB/general/chargemode_config/pv_charging/phases_to_use'
-							] == 0
-						"
-						title="Verzögerung automat. Phasenumschaltung"
-						:min="1"
-						:max="15"
-						:step="1"
-						unit="Min."
-						:model-value="
-							$store.state.mqtt[
-								'openWB/general/chargemode_config/pv_charging/phase_switch_delay'
-							]
-						"
-						@update:model-value="
-							updateState(
-								'openWB/general/chargemode_config/pv_charging/phase_switch_delay',
-								$event,
-							)
-						"
-					>
-						<template #help>
-							Um zu viele Umschaltungen zu vermeiden, wird Anhand
-							dieses Wertes definiert, wann die Umschaltung
-							erfolgen soll. Ist für durchgehend x Minuten die
-							Maximalstromstärke erreicht, wird auf mehrphasige
-							Ladung umgestellt. Ist die Ladung nur für ein
-							Intervall unterhalb der Maximalstromstärke, beginnt
-							das Intervall für die Umschaltung erneut. Ist die
-							Ladung im mehrphasigen Modus für 16 - x Minuten auf
-							der Minimalstromstärke, wird wieder auf einphasige
-							Ladung gewechselt.
-						</template>
-					</openwb-base-range-input>
 				</div>
 			</openwb-base-card>
 			<openwb-base-card title="Speicher-Beachtung">
@@ -621,7 +585,6 @@ export default {
 				"openWB/general/chargemode_config/pv_charging/switch_off_threshold",
 				"openWB/general/chargemode_config/pv_charging/switch_off_delay",
 				"openWB/general/chargemode_config/pv_charging/phases_to_use",
-				"openWB/general/chargemode_config/pv_charging/phase_switch_delay",
 				"openWB/general/chargemode_config/pv_charging/bat_mode",
 				"openWB/general/chargemode_config/pv_charging/bat_power_reserve",
 				"openWB/general/chargemode_config/pv_charging/bat_power_reserve_active",

--- a/src/views/ScheduledChargeConfig.vue
+++ b/src/views/ScheduledChargeConfig.vue
@@ -41,7 +41,7 @@
 					</openwb-base-button-group-input>
 				</div>
 			</openwb-base-card>
-			<openwb-base-card title="Phasenumschaltung Zielladen mit PV-Überschuss">
+			<openwb-base-card title="Phasenumschaltung bei PV-Überschuss">
 				<div v-if="$store.state.mqtt['openWB/general/extern'] === true">
 					<openwb-base-alert subtype="info">
 						Diese Einstellungen sind nicht verfügbar, solange sich

--- a/src/views/ScheduledChargeConfig.vue
+++ b/src/views/ScheduledChargeConfig.vue
@@ -10,7 +10,7 @@
 				</div>
 				<div v-else>
 					<openwb-base-button-group-input
-						title="Anzahl Phasen"
+						title="Anzahl Phasen Zielladen"
 						:buttons="[
 							{ buttonValue: 1, text: '1' },
 							{ buttonValue: 3, text: 'Maximum' },
@@ -39,18 +39,9 @@
 							zwischen 1- und 3-phasig (s.g. 1p3p).
 						</template>
 					</openwb-base-button-group-input>
-				</div>
-			</openwb-base-card>
-			<openwb-base-card title="Phasenumschaltung bei PV-Überschuss">
-				<div v-if="$store.state.mqtt['openWB/general/extern'] === true">
-					<openwb-base-alert subtype="info">
-						Diese Einstellungen sind nicht verfügbar, solange sich
-						diese openWB im Steuerungsmodus "secondary" befindet.
-					</openwb-base-alert>
-				</div>
-				<div v-else>
+					<hr />
 					<openwb-base-button-group-input
-						title="Anzahl Phasen"
+						title="Anzahl Phasen bei PV-Überschuss"
 						:buttons="[
 							{ buttonValue: 1, text: '1' },
 							{ buttonValue: 3, text: 'Maximum' },

--- a/src/views/ScheduledChargeConfig.vue
+++ b/src/views/ScheduledChargeConfig.vue
@@ -41,6 +41,46 @@
 					</openwb-base-button-group-input>
 				</div>
 			</openwb-base-card>
+			<openwb-base-card title="Phasenumschaltung Zielladen mit PV-Überschuss">
+				<div v-if="$store.state.mqtt['openWB/general/extern'] === true">
+					<openwb-base-alert subtype="info">
+						Diese Einstellungen sind nicht verfügbar, solange sich
+						diese openWB im Steuerungsmodus "secondary" befindet.
+					</openwb-base-alert>
+				</div>
+				<div v-else>
+					<openwb-base-button-group-input
+						title="Anzahl Phasen"
+						:buttons="[
+							{ buttonValue: 1, text: '1' },
+							{ buttonValue: 3, text: 'Maximum' },
+							{ buttonValue: 0, text: 'Automatik' },
+						]"
+						:model-value="
+							$store.state.mqtt[
+								'openWB/general/chargemode_config/scheduled_charging/phases_to_use_pv'
+							]
+						"
+						@update:model-value="
+							updateState(
+								'openWB/general/chargemode_config/scheduled_charging/phases_to_use_pv',
+								$event,
+							)
+						"
+					>
+						<template #help>
+							Hier kann eingestellt werden, ob Ladevorgänge im
+							Modus "Zielladen" bei Laden mit PV-Überschuss 
+							mit nur einer Phase oder dem möglichen Maximum in 
+							Abhängigkeit der "Ladepunkt"- und "Fahrzeug"-Einstellungen 
+							durchgeführt werden. Im Modus "Automatik" entscheidet die Regelung, 
+							welche Einstellung genutzt wird, um das Ziel zu erreichen.
+							Voraussetzung ist die verbaute Umschaltmöglichkeit
+							zwischen 1- und 3-phasig (s.g. 1p3p).
+						</template>
+					</openwb-base-button-group-input>
+				</div>
+			</openwb-base-card>
 			<openwb-base-submit-buttons
 				formName="scheduledChargeConfigForm"
 				@save="$emit('save')"
@@ -62,6 +102,7 @@ export default {
 			mqttTopicsToSubscribe: [
 				"openWB/general/extern",
 				"openWB/general/chargemode_config/scheduled_charging/phases_to_use",
+				"openWB/general/chargemode_config/scheduled_charging/phases_to_use_pv",
 			],
 		};
 	},

--- a/src/views/ScheduledChargeConfig.vue
+++ b/src/views/ScheduledChargeConfig.vue
@@ -70,11 +70,12 @@
 					>
 						<template #help>
 							Hier kann eingestellt werden, ob Ladevorgänge im
-							Modus "Zielladen" bei Laden mit PV-Überschuss 
-							mit nur einer Phase oder dem möglichen Maximum in 
-							Abhängigkeit der "Ladepunkt"- und "Fahrzeug"-Einstellungen 
-							durchgeführt werden. Im Modus "Automatik" entscheidet die Regelung, 
-							welche Einstellung genutzt wird, um das Ziel zu erreichen.
+							Modus "Zielladen" bei Laden mit PV-Überschuss mit
+							nur einer Phase oder dem möglichen Maximum in
+							Abhängigkeit der "Ladepunkt"- und
+							"Fahrzeug"-Einstellungen durchgeführt werden. Im
+							Modus "Automatik" entscheidet die Regelung, welche
+							Einstellung genutzt wird, um das Ziel zu erreichen.
 							Voraussetzung ist die verbaute Umschaltmöglichkeit
 							zwischen 1- und 3-phasig (s.g. 1p3p).
 						</template>

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -227,12 +227,6 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
-								Insofern Freigabe durch ID-Tags im
-								Ladepunkt-Profil aktiviert wurde, müssen die den
-								Fahrzeugen zugeordnete ID-Tags auch in das
-								entsprechende Ladepunkt-Profil eingetragen
-								werden, um zuzuordnen, an welchen Ladepunkten
-								die ID-Tags verwendet werden dürfen.<br />
 								<span v-html="$store.state.text.rfidWiki" />
 							</openwb-base-alert>
 							<hr />

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -227,12 +227,12 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
-								Insofern Freigabe durch ID-Tags im Ladepunkt-Profil
-								aktiviert wurde, müssen die den Fahrzeugen zugeordnete 
-								ID-Tags auch in das entsprechende Ladepunkt-Profil
-								eingetragen werden, um zuzuordnen, an welchen
-								Ladepunkten die ID-Tags verwendet werden
-								dürfen.<br />
+								Insofern Freigabe durch ID-Tags im
+								Ladepunkt-Profil aktiviert wurde, müssen die den
+								Fahrzeugen zugeordnete ID-Tags auch in das
+								entsprechende Ladepunkt-Profil eingetragen
+								werden, um zuzuordnen, an welchen Ladepunkten
+								die ID-Tags verwendet werden dürfen.<br />
 								<span v-html="$store.state.text.rfidWiki" />
 							</openwb-base-alert>
 							<hr />


### PR DESCRIPTION
Problem:
Die Einstellung zur Verzögerung der Phasenumschaltung befindet sich unter dem Punkt Ladeeinstellungen Phasenumschaltung und ist nur sichtbar, wenn diese auf Automatik gestellt ist. Zudem beeinflusst die Verzögerung aber auch das Zielladen, welche diese Einstellung allerdings in den Optionen Ladeeinstellungen -> Zielladen nicht bietet. Die Phasenumschaltung in PV-Laden beeinflusst nicht die Phasenumschaltung beim Zielladen, auch nicht, wenn im Modus Zielladen mit PV-Überschuss geladen wird.

Lösung:
Die Einstellung Verzögerung der Phasenumschaltung wandert in die Option Übergreifendes und kann dort immer eingestellt werden, wobei sich diese Einstellung auf PV-Laden sowie Zielladen auswirkt. Dazu wurde:
1. Das topic geändert
2. Der Slider Verzögerung Phasenumschaltung in Übergreifendes migriert
3. Neue Auswahloption Phasenumschaltung bei PV-Laden unter Zielladen hinzugefügt

Dadurch lässt sich die Phasenumschaltung im Modus Zielladen bei PV-Überschuss nun einstellen