### PR TITLE
Neues Konzept ID-Tag

### DIFF
--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -458,33 +458,37 @@
 							</template>
 						</openwb-base-text-input>
 						<hr />
-						<div
-							v-if="
-								$store.state.mqtt[
-									'openWB/optional/rfid/active'
-								] === true
-							"
-						>
 							<openwb-base-heading>
 								Zugangskontrolle
 							</openwb-base-heading>
 							<openwb-base-button-group-input
-								title="Freigabe durch ID-Tags"
-								:buttons="[
-									{ buttonValue: false, text: 'Nein' },
-									{ buttonValue: true, text: 'Ja' },
-								]"
-								:model-value="chargePointTemplate.rfid_enabling"
-								@update:model-value="
-									updateState(
-										chargePointTemplateKey,
-										$event,
-										'rfid_enabling',
-									)
-								"
-							/>
-							<div v-if="chargePointTemplate.rfid_enabling">
-								<openwb-base-array-input
+							title="Sperre nach Abstecken"
+							:buttons="[
+								{
+									buttonValue: false,
+									text: 'Nein',
+									class: 'btn-outline-danger',
+								},
+								{
+									buttonValue: true,
+									text: 'Ja',
+									class: 'btn-outline-success',
+								},
+							]"
+							:model-value="chargePointTemplate.disable_after_unplug"
+							@update:model-value="
+								updateState(
+									chargePointTemplateKey,
+									$event,
+									'disable_after_unplug',
+								)
+							"
+						>
+							<template #help>
+								Sperrt den Ladepunkt nach Abstecken eines Fahrzeuges
+							</template>
+						</openwb-base-button-group-input>
+							<openwb-base-array-input
 									title="Zugeordnete ID-Tags"
 									noElementsMessage="Keine ID-Tags zugeordnet."
 									:model-value="
@@ -499,22 +503,11 @@
 									"
 								>
 									<template #help>
-										Wenn hier Tags eingetragen werden,
-										können nur die eingetragenen Tags zur
-										Fahrzeug-Zuordnung genutzt werden. Sind
-										keine Tags eingetragen, wird nur die
-										Zuordnung zum Fahrzeug geprüft. In
-										diesem Fall können alle Fahrzeuge diesen
-										Ladepunkt nutzen.
-										<br />
-										<span
-											v-html="$store.state.text.rfidWiki"
-										></span>
+										Die hier eingetragenen ID-Tags dienen nur zum Entsperren des
+										Ladepunktes
 									</template>
 								</openwb-base-array-input>
 								<hr />
-							</div>
-						</div>
 						<openwb-base-heading>
 							Angaben zum konfigurierten Ladestrom der openWB
 						</openwb-base-heading>

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -462,32 +462,32 @@
 								Zugangskontrolle
 							</openwb-base-heading>
 							<openwb-base-button-group-input
-							title="Sperre nach Abstecken"
-							:buttons="[
-								{
-									buttonValue: false,
-									text: 'Nein',
-									class: 'btn-outline-danger',
-								},
-								{
-									buttonValue: true,
-									text: 'Ja',
-									class: 'btn-outline-success',
-								},
-							]"
-							:model-value="chargePointTemplate.disable_after_unplug"
-							@update:model-value="
-								updateState(
-									chargePointTemplateKey,
-									$event,
-									'disable_after_unplug',
-								)
-							"
-						>
-							<template #help>
-								Sperrt den Ladepunkt nach Abstecken eines Fahrzeuges
-							</template>
-						</openwb-base-button-group-input>
+								title="Sperre nach Abstecken"
+								:buttons="[
+									{
+										buttonValue: false,
+										text: 'Nein',
+										class: 'btn-outline-danger',
+									},
+									{
+										buttonValue: true,
+										text: 'Ja',
+										class: 'btn-outline-success',
+									},
+								]"
+								:model-value="chargePointTemplate.disable_after_unplug"
+								@update:model-value="
+									updateState(
+										chargePointTemplateKey,
+										$event,
+										'disable_after_unplug',
+									)
+								"
+							>
+								<template #help>
+									Sperrt den Ladepunkt nach Abstecken eines Fahrzeuges
+								</template>
+							</openwb-base-button-group-input>
 							<openwb-base-array-input v-if="chargePointTemplate.disable_after_unplug"
 									title="Zugeordnete ID-Tags"
 									noElementsMessage="Keine ID-Tags zugeordnet."

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -503,8 +503,8 @@
 									"
 								>
 									<template #help>
-										Die hier eingetragenen ID-Tags dienen nur zum Entsperren des
-										Ladepunktes
+										Die hier eingetragenen ID-Tags dienen ausschließlich zum Entsperren des
+										Ladepunktes.
 									</template>
 								</openwb-base-array-input>
 								<hr />

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -458,56 +458,58 @@
 							</template>
 						</openwb-base-text-input>
 						<hr />
-							<openwb-base-heading>
-								Zugangskontrolle
-							</openwb-base-heading>
-							<openwb-base-button-group-input
-								title="Sperre nach Abstecken"
-								:buttons="[
-									{
-										buttonValue: false,
-										text: 'Nein',
-										class: 'btn-outline-danger',
-									},
-									{
-										buttonValue: true,
-										text: 'Ja',
-										class: 'btn-outline-success',
-									},
-								]"
-								:model-value="chargePointTemplate.disable_after_unplug"
-								@update:model-value="
-									updateState(
-										chargePointTemplateKey,
-										$event,
-										'disable_after_unplug',
-									)
-								"
-							>
-								<template #help>
-									Sperrt den Ladepunkt nach Abstecken eines Fahrzeuges
-								</template>
-							</openwb-base-button-group-input>
-							<openwb-base-array-input v-if="chargePointTemplate.disable_after_unplug"
-									title="Zugeordnete ID-Tags"
-									noElementsMessage="Keine ID-Tags zugeordnet."
-									:model-value="
-										chargePointTemplate.valid_tags
-									"
-									@update:model-value="
-										updateState(
-											chargePointTemplateKey,
-											$event,
-											'valid_tags',
-										)
-									"
-								>
-									<template #help>
-										Die hier eingetragenen ID-Tags dienen ausschließlich zum Entsperren des
-										Ladepunktes.
-									</template>
-								</openwb-base-array-input>
-								<hr />
+						<openwb-base-heading>
+							Zugangskontrolle
+						</openwb-base-heading>
+						<openwb-base-button-group-input
+							title="Sperre nach Abstecken"
+							:buttons="[
+								{
+									buttonValue: false,
+									text: 'Nein',
+									class: 'btn-outline-danger',
+								},
+								{
+									buttonValue: true,
+									text: 'Ja',
+									class: 'btn-outline-success',
+								},
+							]"
+							:model-value="
+								chargePointTemplate.disable_after_unplug
+							"
+							@update:model-value="
+								updateState(
+									chargePointTemplateKey,
+									$event,
+									'disable_after_unplug',
+								)
+							"
+						>
+							<template #help>
+								Sperrt den Ladepunkt nach Abstecken eines
+								Fahrzeuges
+							</template>
+						</openwb-base-button-group-input>
+						<openwb-base-array-input
+							v-if="chargePointTemplate.disable_after_unplug"
+							title="Zugeordnete ID-Tags"
+							noElementsMessage="Keine ID-Tags zugeordnet."
+							:model-value="chargePointTemplate.valid_tags"
+							@update:model-value="
+								updateState(
+									chargePointTemplateKey,
+									$event,
+									'valid_tags',
+								)
+							"
+						>
+							<template #help>
+								Die hier eingetragenen ID-Tags dienen
+								ausschließlich zum Entsperren des Ladepunktes.
+							</template>
+						</openwb-base-array-input>
+						<hr />
 						<openwb-base-heading>
 							Angaben zum konfigurierten Ladestrom der openWB
 						</openwb-base-heading>

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -488,7 +488,7 @@
 								Sperrt den Ladepunkt nach Abstecken eines Fahrzeuges
 							</template>
 						</openwb-base-button-group-input>
-							<openwb-base-array-input
+							<openwb-base-array-input v-if="chargePointTemplate.disable_after_unplug"
 									title="Zugeordnete ID-Tags"
 									noElementsMessage="Keine ID-Tags zugeordnet."
 									:model-value="

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -227,7 +227,7 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
-								Die hier eingetragenen ID-Tags dienen nur zur Fahrzeugzuordnung<br />
+								Die hier eingetragenen ID-Tags dienen ausschließlich der Fahrzeugzuordnung.<br />
 								<span v-html="$store.state.text.rfidWiki" />
 							</openwb-base-alert>
 							<hr />

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -1048,35 +1048,6 @@
 							</template>
 						</openwb-base-button-group-input>
 						<openwb-base-button-group-input
-							title="Sperre nach Abstecken"
-							:buttons="[
-								{
-									buttonValue: false,
-									text: 'Nein',
-									class: 'btn-outline-danger',
-								},
-								{
-									buttonValue: true,
-									text: 'Ja',
-									class: 'btn-outline-success',
-								},
-							]"
-							:model-value="template.disable_after_unplug"
-							@update:model-value="
-								updateState(
-									templateKey,
-									$event,
-									'disable_after_unplug',
-								)
-							"
-						>
-							<template #help>
-								Wird ein Fahrzeug mit diesem Profil abgesteckt,
-								dann wird der betroffene Ladepunkt automatisch
-								deaktiviert.
-							</template>
-						</openwb-base-button-group-input>
-						<openwb-base-button-group-input
 							title="Standard nach Abstecken"
 							:buttons="[
 								{

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -227,6 +227,7 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
+								Die hier eingetragenen ID-Tags dienen nur zur Fahrzeugzuordnung<br />
 								<span v-html="$store.state.text.rfidWiki" />
 							</openwb-base-alert>
 							<hr />

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -227,7 +227,8 @@
 								"
 							/>
 							<openwb-base-alert subtype="info">
-								Die hier eingetragenen ID-Tags dienen ausschließlich der Fahrzeugzuordnung.<br />
+								Die hier eingetragenen ID-Tags dienen
+								ausschließlich der Fahrzeugzuordnung.<br />
 								<span v-html="$store.state.text.rfidWiki" />
 							</openwb-base-alert>
 							<hr />


### PR DESCRIPTION
Neues Konzept für die ID-Zuordnung
1. Sperre nach Abstecken wandert in den Reiter Ladepunkt-Profile
2. Zugangskontrolle in Ladepunkt-Profile entfällt
3. Zugeordnete ID-Tags werden nur angezeigt, wenn Sperre nach Abstecken aktiv ist
4. Anpassung der Hilfe-Texte

Die im Ladepunkt-Profil eingetragenen ID-Tags sollen nur den Ladepunkt entsperren und die im Fahrzeug eingetragenen ID-Tags sollen nur ein Fahrzeug zuordnen. 

Sperre nach Abstecken:
Ladepunkt sperrt automatisch, wenn abgesteckt wird und Sperre nach Abstecken aktiviert ist
Diese Sperre lässt sich in der UI händisch lösen, wodurch dann das letzte ausgewählte Fahrzeug den Ladevorgang startet
Diese Sperre lässt sich durch einen ID-Tag lösen, welcher im Ladepunkt-Profil hinterlegt ist
Ist derselbe ID-Tag auch einem Fahrzeug zugeordnet, dann wird der Ladepunkt entsperrt und das dem ID-Tag zugeordnete Fahrzeug startet den Ladepunkt
Sind mehrere gleiche ID-Tags verschiedenen Fahrzeugen zugeordnet, dann startet das erste erkannte Fahrzeug den Ladevorgang (das erste in der Liste)
Solange der Ladepunkt gesperrt ist, wird kein gültiger einem Fahrzeug zugeordneter ID-Tag akzeptiert
Wird der Ladepunkt mit gültigem ID-Tag entsperrt, dann startet das zuletzt ausgewählte Fahrzeug den Ladevorgang, insofern dieser ID-Tag nicht auch einem Fahrzeug zugeordnet wurde

Standard nach Abstecken:
Startet ein Fahrzeug über ID-Tag den Ladevorgang und ist in diesem Fahrzeug Standard nach Abstecken aktiviert, dann wird nach Abstecken auf Standardfahrzeug gewechselt, unabhängig davon, welches Fahrzeug vorher ausgewählt war
Startet ein Fahrzeug über ID-Tag den Ladevorgang und ist in diesem Fahrzeug Standard nach Abstecken nicht aktiviert, dann wird nach Abstecken auf das letzte vorher ausgewählte Fahrzeug gewechselt

getestet mit MQTT Explorer - Stand 05.06.2024
