### PR TITLE
fault_str: render newline, etc.

### DIFF
--- a/src/components/status/VehicleCard.vue
+++ b/src/components/status/VehicleCard.vue
@@ -41,7 +41,7 @@
 				fixed-width
 				:icon="['fas', 'check-circle']"
 			/>
-			Modulmeldung:<br /><span style="white-space: pre-wrap;">
+			Modulmeldung:<br /><span style="white-space: pre-wrap">
 			{{
 				$store.state.mqtt[
 					"openWB/vehicle/" + vehicleIndex + "/get/fault_str"

--- a/src/components/status/VehicleCard.vue
+++ b/src/components/status/VehicleCard.vue
@@ -41,12 +41,12 @@
 				fixed-width
 				:icon="['fas', 'check-circle']"
 			/>
-			Modulmeldung:<br />
+			Modulmeldung:<br /><span style="white-space: pre-wrap;">
 			{{
 				$store.state.mqtt[
 					"openWB/vehicle/" + vehicleIndex + "/get/fault_str"
 				]
-			}}
+			}}</span>
 		</openwb-base-alert>
 		<openwb-base-heading>Fahrzeugdaten</openwb-base-heading>
 		<openwb-base-number-input


### PR DESCRIPTION
Adding to Modulmeldung <span style="white-space: pre-wrap;"> ... </span> to render newline correctly.
smarteq Module will set vehicle fault_state rsp. fault_str and rendering newline will produce more readable information.