### PR TITLE
Ziel-SoC/SoC-Limit

### DIFF
--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -1704,7 +1704,7 @@
 								</template>
 							</openwb-base-button-group-input>
 							<openwb-base-range-input
-								title="Ziel-SoC"
+								title="Fahrzeug-SoC zum Zielzeitpunkt"
 								v-if="plan.limit.selected == 'soc'"
 								:min="5"
 								:max="100"
@@ -1721,11 +1721,11 @@
 							>
 								<template #help>
 									SoC, der zum angegebenen Zeitpunkt erreicht
-									werden soll.
+									werden soll (Ziel-SoC).
 								</template>
 							</openwb-base-range-input>
 							<openwb-base-range-input
-								title="SoC-Limit"
+								title="Fahrzeug-SoC mit Überschuss"
 								v-if="plan.limit.selected == 'soc'"
 								:min="5"
 								:max="100"
@@ -1743,7 +1743,8 @@
 								<template #help>
 									Nach Erreichen des Ziel-SoCs wird mit
 									Überschuss weiter geladen, bis das SoC-Limit
-									erreicht wird.
+									erreicht wird. Sobald das SoC-Limit erreicht wurde,
+									findet keine Ladung mehr mit Überschuss statt!
 								</template>
 							</openwb-base-range-input>
 							<openwb-base-number-input


### PR DESCRIPTION
Stellt man im Lade-Profil der Fahrzeuge auf Zielladen ein und hinterlegt einen Plan mit Uhrzeit und stellt Ziel auf SoC können Ziel-SoC (Akkustand, der zum Zeitpunkt erreicht werden muss) und SoC-Limit (Akkustand, der zum Zeitpunkt mit PV-Überschuss erreicht werden kann) per Slider (5 - 100 %) eingestellt werden.

Ziel-SoC beschreibt hier den Akkustand zum Zielzeitpunkt (Sofortladen des Fahrzeuges) und SoC-Limit (Laden des Fahrzeuges mit PV-Überschuss) beschreibt das Laden mit PV-Überschuss, wenn PV-Überschuss vorhanden und noch genug Zeit für das Erreichen des Ladeziels vorhanden ist

Problem:
Wird der Ziel-SoC kleiner als das SoC-Limit gewählt, dann stoppt momentan der Ladevorgang beim Erreichen des SoC-Limits, obwohl der Ziel-SoC noch nicht erreicht wurde.

Lösung: Anpassung des Codes
Der Ladevorgang stoppt erst, wenn Ziel-SoC UND SoC-Limit erreicht wurde.
Wird der SoC-Limit erreicht, stoppen jegliche Ladevorgänge mit PV-Überschuss. Nur wenn sich der soc unterhalb des SoC-Limits befindet, ist eine PV-Überschuss Ladung möglich (auch bei preisbasiertem Laden).
Liegt der Zielzeitpunkt zu weit entfernt, wird immer in den Modus Sofortladen gewechselt, sodass der Ladevorgang rechtzeitig abgeschlossen wird und die Stromstärke entsprechend angepasst.
Preisbasiertes Laden hat trotzdem Priorität, falls es aktiviert wurde und Überschuss vorhanden ist. Werden günstige Stunden ermittelt und ist noch genügend Zeit vorhanden, dann startet der Ladevorgang im Modus Sofortladen, auch wenn PV-Überschuss vorhanden ist.
Sind keine günstigen Stunden ermittelt worden und ist das SoC-Limit erreicht, dann findet auch trotz PV-Überschuss kein Laden mit Überschuss statt.
Sind keine günstigen Stunden ermittelt worden und ist das SoC-Limit nicht erreicht, dann wird mit Überschuss geladen.

Allerdings wurde hier nicht überprüft, ob die Zeiten korrekt ermittelt wurden. Im MQTT Explorer werden die Zeiten zum Erreichen des Ladeziels anders ermittelt als im Betrieb. Der Mechanismus zum Ermitteln und Umschalten aber funktioniert.
Es sieht so aus, dass wenn das Zielladen startet, der Strom aus PV-Anlage und Netz gleichermassen entnommen wird, falls PV-Überschuss vorhanden. Der Speicher scheint unberührt zu bleiben.

Es wird jetzt mit dem SoC-Limit also nur verhindert, dass wenn das Ziel-SoC noch nicht erreicht wurde, aber noch genug Zeit zum Erreichen vorhanden ist, dass der Fahrzeug-Akku nicht mit PV-Überschuss gefüllt wird, wenn das SoC-Limit bereits erreicht wurde.

Getestet mit MQTT-Explorer Stand 12. Juni 2024