### PR TITLE
Geräteliste gruppieren

### DIFF
--- a/src/components/electricity_tariffs/energycharts/electricity_tariff.vue
+++ b/src/components/electricity_tariffs/energycharts/electricity_tariff.vue
@@ -2,7 +2,7 @@
 	<div class="electricity-tariff-energycharts">
 		<openwb-base-alert subtype="info">
 			Börsenstrompreise von Energy Charts (energy-charts.info)<br />
-			Die Rohdaten werden von Wissenschaftlern des Fraunhofer-Institut für
+			Die Rohdaten werden von Wissenschaftlern des Fraunhofer-Instituts für
 			Solare Energiesysteme ISE aus zahlreichen Quellen stündlich oder
 			täglich abgerufen und für die Darstellung aufbereitet.
 		</openwb-base-alert>

--- a/src/components/electricity_tariffs/energycharts/electricity_tariff.vue
+++ b/src/components/electricity_tariffs/energycharts/electricity_tariff.vue
@@ -2,7 +2,7 @@
 	<div class="electricity-tariff-energycharts">
 		<openwb-base-alert subtype="info">
 			Börsenstrompreise von Energy Charts (energy-charts.info)<br />
-			Die Rohdaten werden von Wissenschaftlern des Fraunhofer-Instituts für
+			Die Rohdaten werden von Wissenschaftlern des Fraunhofer-Institut für
 			Solare Energiesysteme ISE aus zahlreichen Quellen stündlich oder
 			täglich abgerufen und für die Darstellung aufbereitet.
 		</openwb-base-alert>

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -262,15 +262,12 @@
 						:options="getManufactureList"
 						:model-value="selectManufacturer"
 						@update:model-value="selectManufacturer = $event"
-						
 					>
-					<template #append>
-							<span class="col-1">
-								
-							</span>
-							</template>
+						<template #append>
+							<span class="col-1"> </span>
+						</template>
 					</openwb-base-select-input>
-					
+
 					<openwb-base-select-input
 						class="mb-2"
 						title="Verfügbare Geräte"
@@ -279,7 +276,6 @@
 						:model-value="deviceToAdd"
 						@update:model-value="deviceToAdd = $event"
 					>
-					
 						<template #append>
 							<span class="col-1">
 								<openwb-base-click-button
@@ -420,53 +416,89 @@ export default {
 		},
 		getManufactureList: {
 			get() {
-			if(this.manufactureList_arr == 0){
-				this.manufactureList_arr.push({ text: 'openWB', value: 'openWB', group: 'openWB' });
-				this.manufactureList_arr.push({ text: 'generisch', value: 'generic', group: "generic" });
-				this.manufactureList_arr.push({ text: 'Systemhersteller', value: 'other', group: "other" });
-			}
-			return this.manufactureList_arr;
-			}
+				if (this.manufactureList_arr == 0) {
+					this.manufactureList_arr.push({
+						text: "openWB",
+						value: "openWB",
+						group: "openWB",
+					});
+					this.manufactureList_arr.push({
+						text: "generisch",
+						value: "generic",
+						group: "generic",
+					});
+					this.manufactureList_arr.push({
+						text: "Systemhersteller",
+						value: "other",
+						group: "other",
+					});
+				}
+				return this.manufactureList_arr;
+			},
 		},
 		getDeviceList: {
 			get() {
-			if(this.$store.state.mqtt[
-				"openWB/system/configurable/devices_components"
-			]){
-				for (const element of Object.values(this.$store.state.mqtt[
-				"openWB/system/configurable/devices_components"
-			])) {
-				if (element.group.includes("openWB") && !this.run_end) {
-					this.openWB_arr.push({ value: element.value, group: element.group, text: element.text });
-				}
-			}
-				for (const element of Object.values(this.$store.state.mqtt[
-				"openWB/system/configurable/devices_components"
-			])) {if (element.group.includes("generic")&& !this.run_end) {
-					this.generic_arr.push({ value: element.value, group: element.group, text: element.text });
+				if (
+					this.$store.state.mqtt[
+						"openWB/system/configurable/devices_components"
+					]
+				) {
+					for (const element of Object.values(
+						this.$store.state.mqtt[
+							"openWB/system/configurable/devices_components"
+						],
+					)) {
+						if (element.group.includes("openWB") && !this.run_end) {
+							this.openWB_arr.push({
+								value: element.value,
+								group: element.group,
+								text: element.text,
+							});
+						}
+					}
+					for (const element of Object.values(
+						this.$store.state.mqtt[
+							"openWB/system/configurable/devices_components"
+						],
+					)) {
+						if (
+							element.group.includes("generic") &&
+							!this.run_end
+						) {
+							this.generic_arr.push({
+								value: element.value,
+								group: element.group,
+								text: element.text,
+							});
+						}
+					}
+					for (const element of Object.values(
+						this.$store.state.mqtt[
+							"openWB/system/configurable/devices_components"
+						],
+					)) {
+						if (element.group.includes("other") && !this.run_end) {
+							this.other_arr.push({
+								value: element.value,
+								group: element.group,
+								text: element.text,
+							});
+						}
+					}
+					this.run_end = true;
+					if (this.selectManufacturer == "openWB") {
+						return this.openWB_arr;
+					}
+					if (this.selectManufacturer == "generic") {
+						return this.generic_arr;
+					}
+					if (this.selectManufacturer == "other") {
+						return this.other_arr;
 					}
 				}
-				for (const element of Object.values(this.$store.state.mqtt[
-				"openWB/system/configurable/devices_components"
-			])) {
-				if (element.group.includes("other")&& !this.run_end) {
-					this.other_arr.push({ value: element.value, group: element.group, text: element.text });
-				}
-			}
-			this.run_end = true;
-			if(this.selectManufacturer == "openWB"){
-				return this.openWB_arr;
-				
-			}
-			if(this.selectManufacturer == "generic"){
-				return this.generic_arr;
-			}
-			if(this.selectManufacturer == "other"){
-				return this.other_arr;
-			}
-		}
-		}
-	},	
+				return [];
+			},
+		},
 	},
 	methods: {
 		getComponentTypeClass(type) {
@@ -505,15 +537,21 @@ export default {
 		},
 		addDevice() {
 			let deviceToAddPath;
-			if(this.$store.state.mqtt[
-				"openWB/system/configurable/devices_components"
-			])
-			{
-				for (const element of Object.values(this.$store.state.mqtt[
+			if (
+				this.$store.state.mqtt[
 					"openWB/system/configurable/devices_components"
-				])) {
+				]
+			) {
+				for (const element of Object.values(
+					this.$store.state.mqtt[
+						"openWB/system/configurable/devices_components"
+					],
+				)) {
 					if (this.deviceToAdd.includes(element.value)) {
-						deviceToAddPath = element.group.concat(".", element.value);
+						deviceToAddPath = element.group.concat(
+							".",
+							element.value,
+						);
 					}
 				}
 				this.$emit("sendCommand", {
@@ -545,26 +583,32 @@ export default {
 		},
 		addComponent(deviceId, deviceType, componentType) {
 			let deviceTypePath;
-			if(this.$store.state.mqtt[
-				"openWB/system/configurable/devices_components"
-			])
-			{
-				for (const element of Object.values(this.$store.state.mqtt[
+			if (
+				this.$store.state.mqtt[
 					"openWB/system/configurable/devices_components"
-				])) {
+				]
+			) {
+				for (const element of Object.values(
+					this.$store.state.mqtt[
+						"openWB/system/configurable/devices_components"
+					],
+				)) {
 					if (deviceType.includes(element.value)) {
-						deviceTypePath = element.group.concat(".", element.value);
+						deviceTypePath = element.group.concat(
+							".",
+							element.value,
+						);
 					}
 				}
-			this.$emit("sendCommand", {
-				command: "addComponent",
-				data: {
-					deviceId: deviceId,
-					deviceType: deviceTypePath,
-					type: componentType,
-				},
-			});
-		}
+				this.$emit("sendCommand", {
+					command: "addComponent",
+					data: {
+						deviceId: deviceId,
+						deviceType: deviceTypePath,
+						type: componentType,
+					},
+				});
+			}
 		},
 		removeComponentModal(
 			deviceId,

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -259,7 +259,7 @@
 						class="mb-2"
 						title="Hersteller"
 						notSelected="Bitte auswählen"
-						:options="getManufactureList"
+						:options="getManufactureList()"
 						:model-value="selectManufacturer"
 						@update:model-value="selectManufacturer = $event"
 					>
@@ -272,7 +272,7 @@
 						class="mb-2"
 						title="Verfügbare Geräte"
 						notSelected="Bitte auswählen"
-						:options="getDeviceList"
+						:options="getDeviceList()"
 						:model-value="deviceToAdd"
 						@update:model-value="deviceToAdd = $event"
 					>
@@ -414,93 +414,86 @@ export default {
 				);
 			},
 		},
-		getManufactureList: {
-			get() {
-				if (this.manufactureList_arr == 0) {
-					this.manufactureList_arr.push({
-						text: "openWB",
-						value: "openWB",
-						group: "openWB",
-					});
-					this.manufactureList_arr.push({
-						text: "generisch",
-						value: "generic",
-						group: "generic",
-					});
-					this.manufactureList_arr.push({
-						text: "Systemhersteller",
-						value: "other",
-						group: "other",
-					});
-				}
-				return this.manufactureList_arr;
-			},
-		},
-		getDeviceList: {
-			get() {
-				if (
-					this.$store.state.mqtt[
-						"openWB/system/configurable/devices_components"
-					]
-				) {
-					for (const element of Object.values(
-						this.$store.state.mqtt[
-							"openWB/system/configurable/devices_components"
-						],
-					)) {
-						if (element.group.includes("openWB") && !this.run_end) {
-							this.openWB_arr.push({
-								value: element.value,
-								group: element.group,
-								text: element.text,
-							});
-						}
-					}
-					for (const element of Object.values(
-						this.$store.state.mqtt[
-							"openWB/system/configurable/devices_components"
-						],
-					)) {
-						if (
-							element.group.includes("generic") &&
-							!this.run_end
-						) {
-							this.generic_arr.push({
-								value: element.value,
-								group: element.group,
-								text: element.text,
-							});
-						}
-					}
-					for (const element of Object.values(
-						this.$store.state.mqtt[
-							"openWB/system/configurable/devices_components"
-						],
-					)) {
-						if (element.group.includes("other") && !this.run_end) {
-							this.other_arr.push({
-								value: element.value,
-								group: element.group,
-								text: element.text,
-							});
-						}
-					}
-					this.run_end = true;
-					if (this.selectManufacturer == "openWB") {
-						return this.openWB_arr;
-					}
-					if (this.selectManufacturer == "generic") {
-						return this.generic_arr;
-					}
-					if (this.selectManufacturer == "other") {
-						return this.other_arr;
-					}
-				}
-				return [];
-			},
-		},
 	},
 	methods: {
+		getManufactureList() {
+			if (this.manufactureList_arr == 0) {
+				this.manufactureList_arr.push({
+					text: "openWB",
+					value: "openWB",
+					group: "openWB",
+				});
+				this.manufactureList_arr.push({
+					text: "generisch",
+					value: "generic",
+					group: "generic",
+				});
+				this.manufactureList_arr.push({
+					text: "Systemhersteller",
+					value: "other",
+					group: "other",
+				});
+			}
+			return this.manufactureList_arr;
+		},
+		getDeviceList() {
+			if (
+				this.$store.state.mqtt[
+					"openWB/system/configurable/devices_components"
+				]
+			) {
+				for (const element of Object.values(
+					this.$store.state.mqtt[
+						"openWB/system/configurable/devices_components"
+					],
+				)) {
+					if (element.group.includes("openWB") && !this.run_end) {
+						this.openWB_arr.push({
+							value: element.value,
+							group: element.group,
+							text: element.text,
+						});
+					}
+				}
+				for (const element of Object.values(
+					this.$store.state.mqtt[
+						"openWB/system/configurable/devices_components"
+					],
+				)) {
+					if (element.group.includes("generic") && !this.run_end) {
+						this.generic_arr.push({
+							value: element.value,
+							group: element.group,
+							text: element.text,
+						});
+					}
+				}
+				for (const element of Object.values(
+					this.$store.state.mqtt[
+						"openWB/system/configurable/devices_components"
+					],
+				)) {
+					if (element.group.includes("other") && !this.run_end) {
+						this.other_arr.push({
+							value: element.value,
+							group: element.group,
+							text: element.text,
+						});
+					}
+				}
+				this.run_end = true;
+				if (this.selectManufacturer == "openWB") {
+					return this.openWB_arr;
+				}
+				if (this.selectManufacturer == "generic") {
+					return this.generic_arr;
+				}
+				if (this.selectManufacturer == "other") {
+					return this.other_arr;
+				}
+			}
+			return [];
+		},
 		getComponentTypeClass(type) {
 			if (type.match(/^(.+_)?counter(_.+)?$/)) {
 				return "danger";

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -259,7 +259,7 @@
 						class="mb-2"
 						title="Hersteller"
 						notSelected="Bitte auswählen"
-						:options="getManufactureList()"
+						:options="getManufactureList"
 						:model-value="selectManufacturer"
 						@update:model-value="selectManufacturer = $event"
 						
@@ -275,7 +275,7 @@
 						class="mb-2"
 						title="Verfügbare Geräte"
 						notSelected="Bitte auswählen"
-						:options="getDeviceList()"
+						:options="getDeviceList"
 						:model-value="deviceToAdd"
 						@update:model-value="deviceToAdd = $event"
 					>
@@ -391,6 +391,7 @@ export default {
 			],
 			deviceToAdd: undefined,
 			selectManufacturer: undefined,
+			run_end: false,
 			showDeviceRemoveModal: false,
 			modalDevice: undefined,
 			modalDeviceName: "",
@@ -417,43 +418,43 @@ export default {
 				);
 			},
 		},
-	},
-	methods: {
-		getManufactureList(){
+		getManufactureList: {
+			get() {
 			if(this.manufactureList_arr == 0){
 				this.manufactureList_arr.push({ text: 'openWB', value: 'openWB', group: 'openWB' });
 				this.manufactureList_arr.push({ text: 'generisch', value: 'generic', group: "generic" });
 				this.manufactureList_arr.push({ text: 'Anderer Hersteller', value: 'other', group: "other" });
 			}
 			return this.manufactureList_arr;
+			}
 		},
-		getDeviceList() {
+		getDeviceList: {
+			get() {
 			if(this.$store.state.mqtt[
 				"openWB/system/configurable/devices_components"
 			]){
 				for (const element of Object.values(this.$store.state.mqtt[
 				"openWB/system/configurable/devices_components"
 			])) {
-				if (element.group.includes("openWB")) {
+				if (element.group.includes("openWB") && !this.run_end) {
 					this.openWB_arr.push({ value: element.value, group: element.group, text: element.text });
-					console.info("HIER ALSO:");
 				}
 			}
 				for (const element of Object.values(this.$store.state.mqtt[
 				"openWB/system/configurable/devices_components"
-			])) {if (element.group.includes("generic")) {
+			])) {if (element.group.includes("generic")&& !this.run_end) {
 					this.generic_arr.push({ value: element.value, group: element.group, text: element.text });
 					}
 				}
 				for (const element of Object.values(this.$store.state.mqtt[
 				"openWB/system/configurable/devices_components"
 			])) {
-				if (element.group.includes("other")) {
+				if (element.group.includes("other")&& !this.run_end) {
 					this.other_arr.push({ value: element.value, group: element.group, text: element.text });
 				}
 			}
+			this.run_end = true;
 			if(this.selectManufacturer == "openWB"){
-				console.info("HIER");
 				return this.openWB_arr;
 				
 			}
@@ -464,7 +465,10 @@ export default {
 				return this.other_arr;
 			}
 		}
+		}
 	},	
+	},
+	methods: {
 		getComponentTypeClass(type) {
 			if (type.match(/^(.+_)?counter(_.+)?$/)) {
 				return "danger";

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -423,7 +423,7 @@ export default {
 			if(this.manufactureList_arr == 0){
 				this.manufactureList_arr.push({ text: 'openWB', value: 'openWB', group: 'openWB' });
 				this.manufactureList_arr.push({ text: 'generisch', value: 'generic', group: "generic" });
-				this.manufactureList_arr.push({ text: 'Anderer Hersteller', value: 'other', group: "other" });
+				this.manufactureList_arr.push({ text: 'Systemhersteller', value: 'other', group: "other" });
 			}
 			return this.manufactureList_arr;
 			}

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -529,31 +529,12 @@ export default {
 			);
 		},
 		addDevice() {
-			let deviceToAddPath;
-			if (
-				this.$store.state.mqtt[
-					"openWB/system/configurable/devices_components"
-				]
-			) {
-				for (const element of Object.values(
-					this.$store.state.mqtt[
-						"openWB/system/configurable/devices_components"
-					],
-				)) {
-					if (this.deviceToAdd.includes(element.value)) {
-						deviceToAddPath = element.group.concat(
-							".",
-							element.value,
-						);
-					}
-				}
-				this.$emit("sendCommand", {
-					command: "addDevice",
-					data: {
-						type: deviceToAddPath,
-					},
-				});
-			}
+			this.$emit("sendCommand", {
+				command: "addDevice",
+				data: {
+					type: this.deviceToAdd,
+				},
+			});
 		},
 		removeDeviceModal(index, name, event) {
 			// prevent further processing of the click event
@@ -575,33 +556,14 @@ export default {
 			}
 		},
 		addComponent(deviceId, deviceType, componentType) {
-			let deviceTypePath;
-			if (
-				this.$store.state.mqtt[
-					"openWB/system/configurable/devices_components"
-				]
-			) {
-				for (const element of Object.values(
-					this.$store.state.mqtt[
-						"openWB/system/configurable/devices_components"
-					],
-				)) {
-					if (deviceType.includes(element.value)) {
-						deviceTypePath = element.group.concat(
-							".",
-							element.value,
-						);
-					}
-				}
-				this.$emit("sendCommand", {
-					command: "addComponent",
-					data: {
-						deviceId: deviceId,
-						deviceType: deviceTypePath,
-						type: componentType,
-					},
-				});
-			}
+			this.$emit("sendCommand", {
+				command: "addComponent",
+				data: {
+					deviceId: deviceId,
+					deviceType: deviceType,
+					type: componentType,
+				},
+			});
 		},
 		removeComponentModal(
 			deviceId,

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -454,12 +454,6 @@ export default {
 							text: element.text,
 						});
 					}
-				}
-				for (const element of Object.values(
-					this.$store.state.mqtt[
-						"openWB/system/configurable/devices_components"
-					],
-				)) {
 					if (element.group.includes("generic") && !this.run_end) {
 						this.generic_arr.push({
 							value: element.value,
@@ -467,12 +461,6 @@ export default {
 							text: element.text,
 						});
 					}
-				}
-				for (const element of Object.values(
-					this.$store.state.mqtt[
-						"openWB/system/configurable/devices_components"
-					],
-				)) {
 					if (element.group.includes("other") && !this.run_end) {
 						this.other_arr.push({
 							value: element.value,
@@ -481,6 +469,7 @@ export default {
 						});
 					}
 				}
+
 				this.run_end = true;
 				if (this.selectManufacturer == "openWB") {
 					return this.openWB_arr;


### PR DESCRIPTION
Alle Geräte im Ordner devices wurden in die drei Unterordner
1. openWB
2. generisch
3. other
migriert. Wenn ein Hersteller mehrfach vertreten war, wurde im Ordner "other" ein Unterordner mit Herstellernamen (z.B. Siemens) erstellt und die einzelnen Geräte dieses Herstellers dort abgelegt.
Dann wurden sämtliche Pfade der module geändert und an die neuen Pfade angepasst. Es wurde ein weiteres Attribut an jedes device angefügt, welches erstens die Gruppe zuordnet und zweitens den neuen Pfad beschreibt (self.group = group).
Dieses Attribut wird im Frontend zur Zuordnung zur Gruppe und ausserdem zur Modifizierung des Pfades, um devices und components hinzuzufügen, genutzt. Die Funktionalität bleibt erhalten, nur die Darstellung hat sich geändert.
Im Frontend gibt es ein neues Auswahlfeld Hersteller, welches die drei Auswahlmöglichkeiten openWB, generisch und Systemhersteller bietet. Wird eine der Optionen gewählt, dann wird im Feld darunter (Verfügbare Geräte) die jeweilige Auswahlliste angezeigt.
Ausserdem wurde der Datastore upgedatet.
Getestet, Stand 18.06.2024