### PR TITLE
Anpassungen Einrichtungsassistent

### DIFF
--- a/src/components/install_assistant/InstallAssistantStep1.vue
+++ b/src/components/install_assistant/InstallAssistantStep1.vue
@@ -18,7 +18,33 @@
 			</p>
 		</template>
 		<template v-slot:content>
-			<DataManagement
+			<div class="system">
+		<openwb-base-alert v-if="!installAssistantActive" subtype="danger">
+			<h2>Achtung!</h2>
+			<p>
+				Vor allen Aktionen auf den folgenden Seiten ist sicherzustellen, dass
+				kein Ladevorgang aktiv ist! Zur Sicherheit bitte zusätzlich alle
+				Fahrzeuge von der Ladestation / den Ladestationen abstecken!
+			</p>
+			<openwb-base-button-group-input
+				title="Ich habe die Warnung verstanden"
+				:buttons="[
+					{
+						buttonValue: false,
+						text: 'Nein',
+						class: 'btn-outline-danger',
+					},
+					{
+						buttonValue: true,
+						text: 'Ja',
+						class: 'btn-outline-success',
+					},
+				]"
+				v-model="this.warningAcknowledged"
+			/>
+		</openwb-base-alert>
+		</div>
+			<DataManagement v-if="warningAcknowledged"
 				:installAssistantActive="true"
 				@send-command="$emit('sendCommand', $event)"
 				@save="$emit('save')"
@@ -51,6 +77,7 @@ export default {
 	},
 	data: () => ({
 		mqttTopicsToSubscribe: [],
+		warningAcknowledged: false,
 	}),
 	methods: {
 		nextPage() {

--- a/src/components/install_assistant/InstallAssistantStep1.vue
+++ b/src/components/install_assistant/InstallAssistantStep1.vue
@@ -19,32 +19,37 @@
 		</template>
 		<template v-slot:content>
 			<div class="system">
-		<openwb-base-alert v-if="!installAssistantActive" subtype="danger">
-			<h2>Achtung!</h2>
-			<p>
-				Vor allen Aktionen auf den folgenden Seiten ist sicherzustellen, dass
-				kein Ladevorgang aktiv ist! Zur Sicherheit bitte zusätzlich alle
-				Fahrzeuge von der Ladestation / den Ladestationen abstecken!
-			</p>
-			<openwb-base-button-group-input
-				title="Ich habe die Warnung verstanden"
-				:buttons="[
-					{
-						buttonValue: false,
-						text: 'Nein',
-						class: 'btn-outline-danger',
-					},
-					{
-						buttonValue: true,
-						text: 'Ja',
-						class: 'btn-outline-success',
-					},
-				]"
-				v-model="this.warningAcknowledged"
-			/>
-		</openwb-base-alert>
-		</div>
-			<DataManagement v-if="warningAcknowledged"
+				<openwb-base-alert
+					v-if="!installAssistantActive"
+					subtype="danger"
+				>
+					<h2>Achtung!</h2>
+					<p>
+						Vor allen Aktionen auf den folgenden Seiten ist
+						sicherzustellen, dass kein Ladevorgang aktiv ist! Zur
+						Sicherheit bitte zusätzlich alle Fahrzeuge von der
+						Ladestation / den Ladestationen abstecken!
+					</p>
+					<openwb-base-button-group-input
+						title="Ich habe die Warnung verstanden"
+						:buttons="[
+							{
+								buttonValue: false,
+								text: 'Nein',
+								class: 'btn-outline-danger',
+							},
+							{
+								buttonValue: true,
+								text: 'Ja',
+								class: 'btn-outline-success',
+							},
+						]"
+						v-model="this.warningAcknowledged"
+					/>
+				</openwb-base-alert>
+			</div>
+			<DataManagement
+				v-if="warningAcknowledged"
 				:installAssistantActive="true"
 				@send-command="$emit('sendCommand', $event)"
 				@save="$emit('save')"

--- a/src/components/install_assistant/InstallAssistantStep1.vue
+++ b/src/components/install_assistant/InstallAssistantStep1.vue
@@ -13,17 +13,8 @@
 				Assistent nun erneut ausgeführt wird.
 			</p>
 			<p>
-				Dazu im Abschnitt "Sicherung / Wiederherstellung" auf Sicherung
-				erstellen klicken.
-			</p>
-			<p>
 				Es wird empfohlen, regelmäßig Sicherungen der Daten zu
 				erstellen.
-			</p>
-			<p>
-				Bitte lesen Sie auch die Hinweistexte, welche durch Klicken auf
-				das Fragezeichensymbol erscheinen. Hier sind weiterführende
-				Informationen zu den Eingabefeldern zu finden.
 			</p>
 		</template>
 		<template v-slot:content>

--- a/src/components/install_assistant/InstallAssistantStep10.vue
+++ b/src/components/install_assistant/InstallAssistantStep10.vue
@@ -12,10 +12,10 @@
 				Die grundlegende Konfiguration der openWB ist abgeschlossen. Du
 				wirst mit Beendigung dieses Assistenten auf die Statusseite
 				weitergeleitet. Bitte überprüfe die dargestellten Informationen
-				und passe bei Unstimmigkeiten die Einstellungen an. Weitere Einstellungen sind für den Betrieb 
-				der openWB als secondary nicht notwendig.
-				Detaillierte Einstellungsmöglichkeiten befinden sich in den
-				jeweiligen Konfigurationsseiten.
+				und passe bei Unstimmigkeiten die Einstellungen an. Weitere
+				Einstellungen sind für den Betrieb der openWB als secondary
+				nicht notwendig. Detaillierte Einstellungsmöglichkeiten befinden
+				sich in den jeweiligen Konfigurationsseiten.
 			</p>
 		</template>
 	</InstallAssistantStepTemplate>

--- a/src/components/install_assistant/InstallAssistantStep10.vue
+++ b/src/components/install_assistant/InstallAssistantStep10.vue
@@ -9,11 +9,12 @@
 		<template v-slot:content>
 			<h2>Die Grundkonfiguration ist abgeschlossen.</h2>
 			<p>
-				Die grundlegende Konfiguration der openWB ist abgeschlossen. Sie
-				werden mit Beendigung dieses Assistenten auf die Statusseite
+				Die grundlegende Konfiguration der openWB ist abgeschlossen. Du
+				wirst mit Beendigung dieses Assistenten auf die Statusseite
 				weitergeleitet. Bitte überprüfe die dargestellten Informationen
-				und passe bei Unstimmigkeiten die Einstellungen an. Weitere
-				detaillierte Einstellungsmöglichkeiten befinden sich in den
+				und passe bei Unstimmigkeiten die Einstellungen an. Weitere Einstellungen sind für den Betrieb 
+				der openWB als secondary nicht notwendig.
+				Detaillierte Einstellungsmöglichkeiten befinden sich in den
 				jeweiligen Konfigurationsseiten.
 			</p>
 		</template>

--- a/src/components/install_assistant/InstallAssistantStep2.vue
+++ b/src/components/install_assistant/InstallAssistantStep2.vue
@@ -19,7 +19,6 @@
 				aktualisieren und falls ein Update verfügbar ist, wird der
 				Update button grün und kann gedrückt werden.
 			</p>
-			<p>Dieser Schritt kann auch übersprungen werden.</p>
 		</template>
 		<template v-slot:content>
 			<SystemView

--- a/src/components/install_assistant/InstallAssistantStep3.vue
+++ b/src/components/install_assistant/InstallAssistantStep3.vue
@@ -8,8 +8,8 @@
 		<template v-slot:help>
 			<p>
 				Hier wird abgefragt, ob ihr System mit mehreren openWBs oder nur
-				mit einer openWB betrieben wird. 
-				Eine openWB kann andere openWBs steuern.
+				mit einer openWB betrieben wird. Eine openWB kann andere openWBs
+				steuern.
 			</p>
 			<p>
 				Zuerst ist im Feld "Steuerungsmodus" festzulegen, ob die openWB

--- a/src/components/install_assistant/InstallAssistantStep3.vue
+++ b/src/components/install_assistant/InstallAssistantStep3.vue
@@ -8,8 +8,8 @@
 		<template v-slot:help>
 			<p>
 				Hier wird abgefragt, ob ihr System mit mehreren openWBs oder nur
-				mit einer openWB betrieben wird. Eine openWB kann andere openWBs
-				steuern, wobei für jeden Ladepunkt eine openWB benötigt wird.
+				mit einer openWB betrieben wird. 
+				Eine openWB kann andere openWBs steuern.
 			</p>
 			<p>
 				Zuerst ist im Feld "Steuerungsmodus" festzulegen, ob die openWB

--- a/src/components/install_assistant/InstallAssistantStep4.vue
+++ b/src/components/install_assistant/InstallAssistantStep4.vue
@@ -30,6 +30,11 @@
 				Weitere Einstellungen sind bei der Vorkonfiguration einer
 				secondary nicht notwendig.
 			</p>
+			<p>
+				Bitte lesen Sie auch die Hinweistexte, welche durch Klicken auf
+				das Fragezeichensymbol erscheinen. Hier sind weiterführende
+				Informationen zu den Eingabefeldern zu finden.
+			</p>
 			<p class="font-weight-bold">
 				Änderungen werden nur bei klicken auf Speichern wirksam!
 			</p>

--- a/src/components/install_assistant/InstallAssistantStep5.vue
+++ b/src/components/install_assistant/InstallAssistantStep5.vue
@@ -25,9 +25,9 @@
 				definiert. Dieses Gerät ist über den Herstellernamen des
 				Energiesystems im Auswahlmenü der verfügbaren Geräte
 				auszuwählen. Unterhalb des Gerätes werden die zugehörigen
-				Komponenten EVU-Zähler, WR und Speicher konfiguriert. 
-				Es können je nach Bedarf beliebig viele Geräte und Komponenten 
-				miteinander kombiniert werden.
+				Komponenten EVU-Zähler, WR und Speicher konfiguriert. Es können
+				je nach Bedarf beliebig viele Geräte und Komponenten miteinander
+				kombiniert werden.
 			</p>
 			<p>
 				Bitte lesen Sie auch die Hinweistexte, welche durch Klicken auf

--- a/src/components/install_assistant/InstallAssistantStep5.vue
+++ b/src/components/install_assistant/InstallAssistantStep5.vue
@@ -25,9 +25,14 @@
 				definiert. Dieses Gerät ist über den Herstellernamen des
 				Energiesystems im Auswahlmenü der verfügbaren Geräte
 				auszuwählen. Unterhalb des Gerätes werden die zugehörigen
-				Komponenten EVU-Zähler, WR und Speicher (Summe = Energiesystem)
-				konfiguriert. Das openWB-System ist sehr flexibel und
-				skalierbar.
+				Komponenten EVU-Zähler, WR und Speicher konfiguriert. 
+				Es können je nach Bedarf beliebig viele Geräte und Komponenten 
+				miteinander kombiniert werden.
+			</p>
+			<p>
+				Bitte lesen Sie auch die Hinweistexte, welche durch Klicken auf
+				das Fragezeichensymbol erscheinen. Hier sind weiterführende
+				Informationen zu den Eingabefeldern zu finden.
 			</p>
 			<p class="font-weight-bold">
 				Änderungen werden nur bei klicken auf Speichern wirksam!

--- a/src/components/install_assistant/InstallAssistantStep6.vue
+++ b/src/components/install_assistant/InstallAssistantStep6.vue
@@ -9,8 +9,8 @@
 			<p>
 				Enthält die steuernde openWB (primary) Ladetechnik, wird bei
 				"Verfügbare Ladepunkte" Interne openWB ausgewählt. Weitere LP
-				werden im primary als Externe openWB (= vorkonfigurierte
-				secondary-openWB) oder andere WB-Typen wie Pro, Satellit
+				werden im primary als Externe openWB (als secondary konfigurierte 
+				openWB) oder andere WB-Typen wie Pro, Satellit
 				eingebunden.
 			</p>
 			<p>
@@ -37,14 +37,10 @@
 				deutlich erhöhte Werte anzeigt, ist die auszuwählende EVU-Phase.
 			</p>
 			<p>
-				Bei mehreren openWBs ist es sinnvoll die Ladepunkte auf
-				unterschiedliche Phasen aufzuteilen.
-			</p>
-			<p>
-				Im grauen Menü Ladepunkt-Profile können neben dem nicht
-				editierbaren Standard-Ladepunkt-Profil auch weitere
-				Ladepunkt-Profile, die andere WB-Typen abbilden, erstellt
-				werden. Dort sind Eintragungen bzgl. des Ladepunkt-Maximalstroms
+				Im grauen Menü Ladepunkt-Profile können neben dem 
+				Standard-Ladepunkt-Profil auch weitere Ladepunkt-Profile, die 
+				andere WB-Typen abbilden, erstellt werden. Dort sind Eintragungen 
+				bzgl. des Ladepunkt-Maximalstroms
 				bei einer Phase bzw. mehreren Phasen vorzunehmen. Die Profile
 				werden abschließend im jeweiligen blauen Ladepunkt mittels
 				Auswahlmenü zugeordnet.

--- a/src/components/install_assistant/InstallAssistantStep6.vue
+++ b/src/components/install_assistant/InstallAssistantStep6.vue
@@ -9,8 +9,8 @@
 			<p>
 				Enthält die steuernde openWB (primary) Ladetechnik, wird bei
 				"Verfügbare Ladepunkte" Interne openWB ausgewählt. Weitere LP
-				werden im primary als Externe openWB (als secondary konfigurierte 
-				openWB) oder andere WB-Typen wie Pro, Satellit
+				werden im primary als Externe openWB (als secondary
+				konfigurierte openWB) oder andere WB-Typen wie Pro, Satellit
 				eingebunden.
 			</p>
 			<p>
@@ -37,13 +37,13 @@
 				deutlich erhöhte Werte anzeigt, ist die auszuwählende EVU-Phase.
 			</p>
 			<p>
-				Im grauen Menü Ladepunkt-Profile können neben dem 
-				Standard-Ladepunkt-Profil auch weitere Ladepunkt-Profile, die 
-				andere WB-Typen abbilden, erstellt werden. Dort sind Eintragungen 
-				bzgl. des Ladepunkt-Maximalstroms
-				bei einer Phase bzw. mehreren Phasen vorzunehmen. Die Profile
-				werden abschließend im jeweiligen blauen Ladepunkt mittels
-				Auswahlmenü zugeordnet.
+				Im grauen Menü Ladepunkt-Profile können neben dem
+				Standard-Ladepunkt-Profil auch weitere Ladepunkt-Profile, die
+				andere WB-Typen abbilden, erstellt werden. Dort sind
+				Eintragungen bzgl. des Ladepunkt-Maximalstroms bei einer Phase
+				bzw. mehreren Phasen vorzunehmen. Die Profile werden
+				abschließend im jeweiligen blauen Ladepunkt mittels Auswahlmenü
+				zugeordnet.
 			</p>
 			<p class="font-weight-bold">
 				Änderungen werden nur bei klicken auf Speichern wirksam!

--- a/src/components/install_assistant/InstallAssistantStep7.vue
+++ b/src/components/install_assistant/InstallAssistantStep7.vue
@@ -36,7 +36,8 @@
 				WR. Die Ladepunkte (z.B. Externe openWB) befinden sich auf
 				derselben Ebene wie der WR und unterhalb des EVU-Zählers.
 				Anpassungen der Anordnungen sind über die Pfeil-Bereiche der
-				Komponenten durch einfaches Verschieben mit der Maus möglich.
+				Komponenten durch einfaches Verschieben mit der Maus oder am
+				Smartphone möglich.
 			</p>
 			<p></p>
 			<p class="font-weight-bold">

--- a/src/components/install_assistant/InstallAssistantStep8.vue
+++ b/src/components/install_assistant/InstallAssistantStep8.vue
@@ -7,11 +7,8 @@
 	>
 		<template v-slot:help>
 			<p>
-				Dies ist neu im Vergleich zu sw1.9 und ermöglicht viele
-				nützliche Funktionen (fahrzeugbezogene Abrechnungen,
-				SoC-Auslesungen uvm.). Vor dem eigentlichen Fahrzeug werden
-				zuerst die Fahrzeug- und Lade-Profile konfiguriert. Zuerst
-				Fahrzeug-Profile und Lade-Profile konfigurieren.
+				Vor dem eigentlichen Fahrzeug werden
+				zuerst die Fahrzeug- und Lade-Profile konfiguriert.
 			</p>
 			<p>
 				Bei nur einem Fahrzeug reicht das Standard-Fahrzeug-Profil aus.
@@ -31,8 +28,7 @@
 				Bei nur einem Fahrzeug reicht das Standard-Lade-Profil aus. Bei
 				mehreren Fahrzeugen können weitere Lade-Profile hinzugefügt
 				werden. Dies erlaubt die Nutzung unterschiedlicher Lademodi je
-				Fahrzeug (z.B. EV1 = Sofortladen, EV2 PV-Laden), sofern sie an
-				unterschiedlichen Ladepunkten laden. Im Anschluss werden die
+				Fahrzeug (z.B. EV1 = Sofortladen, EV2 = PV-Laden). Im Anschluss werden die
 				Voreinstellungen zu den verschiedenen Lademodi konfiguriert.
 			</p>
 			<p>

--- a/src/components/install_assistant/InstallAssistantStep8.vue
+++ b/src/components/install_assistant/InstallAssistantStep8.vue
@@ -7,8 +7,8 @@
 	>
 		<template v-slot:help>
 			<p>
-				Vor dem eigentlichen Fahrzeug werden
-				zuerst die Fahrzeug- und Lade-Profile konfiguriert.
+				Vor dem eigentlichen Fahrzeug werden zuerst die Fahrzeug- und
+				Lade-Profile konfiguriert.
 			</p>
 			<p>
 				Bei nur einem Fahrzeug reicht das Standard-Fahrzeug-Profil aus.
@@ -28,8 +28,9 @@
 				Bei nur einem Fahrzeug reicht das Standard-Lade-Profil aus. Bei
 				mehreren Fahrzeugen können weitere Lade-Profile hinzugefügt
 				werden. Dies erlaubt die Nutzung unterschiedlicher Lademodi je
-				Fahrzeug (z.B. EV1 = Sofortladen, EV2 = PV-Laden). Im Anschluss werden die
-				Voreinstellungen zu den verschiedenen Lademodi konfiguriert.
+				Fahrzeug (z.B. EV1 = Sofortladen, EV2 = PV-Laden). Im Anschluss
+				werden die Voreinstellungen zu den verschiedenen Lademodi
+				konfiguriert.
 			</p>
 			<p>
 				Nun wird das eigentliche Fahrzeug angelegt und mit dem

--- a/src/components/install_assistant/InstallAssistantStep9.vue
+++ b/src/components/install_assistant/InstallAssistantStep9.vue
@@ -10,10 +10,6 @@
 				Wir empfehlen an dieser Stelle eine Sicherung der openWB zu
 				erzeugen.
 			</p>
-			<p>
-				Dazu im Abschnitt "Sicherung / Wiederherstellung" auf Sicherung
-				erstellen klicken.
-			</p>
 		</template>
 		<template v-slot:content>
 			<DataManagement

--- a/src/views/DataManagement.vue
+++ b/src/views/DataManagement.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="system">
-		<openwb-base-alert subtype="danger">
+		<openwb-base-alert v-if="!installAssistantActive" subtype="danger">
 			<h2>Achtung!</h2>
 			<p>
 				Vor allen Aktionen auf dieser Seite ist sicherzustellen, dass
@@ -24,7 +24,7 @@
 				v-model="this.warningAcknowledged"
 			/>
 		</openwb-base-alert>
-		<div v-if="warningAcknowledged">
+		<div v-if="warningAcknowledged || installAssistantActive">
 			<openwb-base-card
 				title="Sicherung / Wiederherstellung"
 				subtype="success"


### PR DESCRIPTION
Der Hilfetext wurde angepasst

Die Warnung, dass sämtliche Konfigurationen erst nach Abstecken und ohne aktiven Ladevorgang durchgeführt werden müssen, wurde angepasst (wird nur einmal vor der Datensicherung angezeigt).