### PR TITLE
formatting with state_str and fault_str

### DIFF
--- a/src/components/status/BatteryCard.vue
+++ b/src/components/status/BatteryCard.vue
@@ -44,9 +44,9 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt["openWB/bat/" + battery.id + "/get/fault_str"]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-heading>Aktuelle Werte</openwb-base-heading>
     <openwb-base-text-input

--- a/src/components/status/BatterySumCard.vue
+++ b/src/components/status/BatterySumCard.vue
@@ -32,7 +32,9 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{ $store.state.mqtt["openWB/bat/get/fault_str"] }}
+      <span style="white-space: pre-wrap">{{
+        $store.state.mqtt["openWB/bat/get/fault_str"]
+      }}</span>
     </openwb-base-alert>
     <openwb-base-heading>Zählerstände</openwb-base-heading>
     <openwb-base-text-input

--- a/src/components/status/ChargePointCard.vue
+++ b/src/components/status/ChargePointCard.vue
@@ -50,19 +50,19 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt[
           "openWB/chargepoint/" + chargePointIndex + "/get/fault_str"
         ]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-alert subtype="info">
       Statusmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt[
           "openWB/chargepoint/" + chargePointIndex + "/get/state_str"
         ]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-checkbox-input
       title="Fahrzeug angesteckt"

--- a/src/components/status/CounterCard.vue
+++ b/src/components/status/CounterCard.vue
@@ -44,11 +44,11 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt[
           "openWB/counter/" + counter.id + "/get/fault_str"
         ]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-alert
       v-if="
@@ -59,11 +59,11 @@
       subtype="info"
     >
       Statusmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt[
           "openWB/counter/" + counter.id + "/get/state_str"
         ]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-heading>Zählerstände</openwb-base-heading>
     <openwb-base-text-input

--- a/src/components/status/ElectricityTariffCard.vue
+++ b/src/components/status/ElectricityTariffCard.vue
@@ -39,7 +39,9 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{ $store.state.mqtt["openWB/optional/et/get/fault_str"] }}
+      <span style="white-space: pre-wrap">{{
+        $store.state.mqtt["openWB/optional/et/get/fault_str"]
+      }}</span>
     </openwb-base-alert>
     <openwb-base-text-input
       title="Anbieter"

--- a/src/components/status/InverterCard.vue
+++ b/src/components/status/InverterCard.vue
@@ -44,9 +44,9 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt["openWB/pv/" + inverter.id + "/get/fault_str"]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-text-input
       title="Zählerstand"

--- a/src/components/status/InverterSumCard.vue
+++ b/src/components/status/InverterSumCard.vue
@@ -32,7 +32,9 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{ $store.state.mqtt["openWB/pv/get/fault_str"] }}
+      <span style="white-space: pre-wrap">{{
+        $store.state.mqtt["openWB/pv/get/fault_str"]
+      }}</span>
     </openwb-base-alert>
     <openwb-base-text-input
       title="Zählerstand"

--- a/src/components/status/RippleControlReceiver.vue
+++ b/src/components/status/RippleControlReceiver.vue
@@ -48,11 +48,11 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt[
           "openWB/general/ripple_control_receiver/get/fault_str"
         ]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-text-input
       title="Status"

--- a/src/components/status/VehicleCard.vue
+++ b/src/components/status/VehicleCard.vue
@@ -49,11 +49,11 @@
         :icon="['fas', 'check-circle']"
       />
       Modulmeldung:<br>
-      {{
+      <span style="white-space: pre-wrap">{{
         $store.state.mqtt[
           "openWB/vehicle/" + vehicleIndex + "/get/fault_str"
         ]
-      }}
+      }}</span>
     </openwb-base-alert>
     <openwb-base-heading>Fahrzeugdaten</openwb-base-heading>
     <openwb-base-number-input


### PR DESCRIPTION
based on #486
allows simple formatting of `fault_str` and `state_str` with line breaks and spaces