### PR TITLE
Ändere 'rfid' zu 'tag' im Fahrzeugobjekt der ChargeLog-Komponente

### DIFF
--- a/src/views/ChargeLog.vue
+++ b/src/views/ChargeLog.vue
@@ -402,7 +402,7 @@ export default {
           },
           vehicle: {
             id: [],
-            rfid: [],
+            tag: [],
             chargemode: [],
             prio: undefined,
           },


### PR DESCRIPTION
Der filter wurde falsch initialisiert. Das Eingabefeld verwendet die Bezeichnung "tag".
Core: https://github.com/openWB/core/pull/2002