### PR TITLE
Add Algodue meter via ModbusTCP

### DIFF
--- a/src/components/devices/algodue/carlo_gavazzi/counter.vue
+++ b/src/components/devices/algodue/carlo_gavazzi/counter.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="device-algodue-counter">
+    <openwb-base-alert subtype="info">
+      ModbusTCP muss aktiviert sein. Ausgelesen wird ID 1 auf Port 502.
+    </openwb-base-alert>
+  </div>
+</template>
+
+<script>
+import ComponentConfigMixin from "../../ComponentConfigMixin.vue";
+
+export default {
+  name: "DeviceAlgodueCounter",
+  mixins: [ComponentConfigMixin],
+};
+</script>

--- a/src/components/devices/algodue/carlo_gavazzi/device.vue
+++ b/src/components/devices/algodue/carlo_gavazzi/device.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="device-carlogavazzi">
+    <openwb-base-heading> Einstellungen für Algodue</openwb-base-heading>
+    <openwb-base-text-input
+      title="IP oder Hostname"
+      subtype="host"
+      required
+      :model-value="device.configuration.ip_address"
+      @update:model-value="updateConfiguration($event, 'configuration.ip_address')"
+    />
+    <openwb-base-number-input
+      title="Port"
+      required
+      :min="1"
+      :max="65535"
+      :model-value="device.configuration.port"
+      @update:model-value="updateConfiguration($event, 'configuration.port')"
+    />
+    <openwb-base-number-input
+      title="Modbus ID"
+      required
+      :model-value="device.configuration.modbus_id"
+      min="1"
+      max="255"
+      @update:model-value="updateConfiguration($event, 'configuration.modbus_id')"
+    />
+  </div>
+</template>
+
+<script>
+import DeviceConfigMixin from "../../DeviceConfigMixin.vue";
+
+export default {
+  name: "DeviceAlgodue",
+  mixins: [DeviceConfigMixin],
+};
+</script>


### PR DESCRIPTION
UI support for https://github.com/openWB/core/pull/1960 

Algodue Meters as EVU-Kit.