### PR TITLE
MQTT topic Pfad and Nummer Formatierung

### DIFF
--- a/src/components/status/CounterCard.vue
+++ b/src/components/status/CounterCard.vue
@@ -160,7 +160,7 @@
               <span v-if="$store.state.mqtt[baseTopic + '/get/fault_state'] != 0">
                 <br />
               </span>
-              <span style="white-space: pre-wrap">{{ $store.state.mqtt["baseTopic + '/get//fault_str"] }}</span>
+              <span style="white-space: pre-wrap">{{ $store.state.mqtt[baseTopic + '/get/fault_str'] }}</span>
             </openwb-base-alert>
           </div>
           <div class="col col-auto pr-0">

--- a/src/components/status/VehicleCard.vue
+++ b/src/components/status/VehicleCard.vue
@@ -43,7 +43,7 @@
       </div>
       <div class="row">
         <div class="col text-right text-monospace">
-          {{ formatNumberTopic($store.state.mqtt[baseTopic + "/get/soc"], 1, 1, 0.001) + " %" }}
+          {{ formatNumberTopic(baseTopic + '/get/soc') + " %" }}
         </div>
         <div class="col text-right text-monospace">
           {{ socRange + " km" }}


### PR DESCRIPTION
Wegen ein ungültige MQTT Pfad wird den Text von Warnungen usw in "CounterCard" nicht angezeigt.
ebenfalls werden Ladestand des Autos in "VehicleCard" nicht angezeigt. 
Die Pfade habe ich korrigiert.