### PR TITLE
fix dynamic component revalidation

### DIFF
--- a/src/components/backup_clouds/OpenwbBackupCloudProxy.vue
+++ b/src/components/backup_clouds/OpenwbBackupCloudProxy.vue
@@ -1,7 +1,7 @@
 <template>
   <openwb-base-heading> Einstellungen für Backup-Cloud Modul "{{ backupCloud.name }}" </openwb-base-heading>
   <component
-    :is="myComponent"
+    :is="getBackupCloudComponent()"
     :backup-cloud="backupCloud"
     @update:configuration="updateConfiguration($event)"
     @send-command="sendCommand($event)"
@@ -18,16 +18,14 @@ export default {
     backupCloud: { type: Object, required: true },
   },
   emits: ["update:configuration", "sendCommand"],
-  computed: {
-    myComponent() {
+  methods: {
+    getBackupCloudComponent() {
       console.debug(`loading backup cloud: ${this.backupCloud.name} (${this.backupCloud.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.backupCloud.type}/backup_cloud.vue`),
         errorComponent: OpenwbBackupCloudFallback,
       });
     },
-  },
-  methods: {
     // event pass through
     updateConfiguration(event) {
       this.$emit("update:configuration", event);

--- a/src/components/charge_points/OpenwbChargePointProxy.vue
+++ b/src/components/charge_points/OpenwbChargePointProxy.vue
@@ -1,14 +1,14 @@
 <template>
   <openwb-base-heading> Einstellungen für Ladepunkt Typ "{{ chargePoint.type }}" </openwb-base-heading>
   <component
-    :is="myChargePointSettingsComponent"
+    :is="getChargePointSettingsComponent()"
     :charge-point="chargePoint"
     @update:configuration="updateConfiguration($event)"
   />
   <hr />
   <openwb-base-heading> Befehle für Ladepunkt Typ "{{ chargePoint.type }}" </openwb-base-heading>
   <component
-    :is="myChargePointCommandsComponent"
+    :is="getChargePointCommandsComponent()"
     :charge-point="chargePoint"
   />
 </template>
@@ -24,23 +24,21 @@ export default {
     chargePoint: { required: true, type: Object },
   },
   emits: ["update:configuration"],
-  computed: {
-    myChargePointSettingsComponent() {
+  methods: {
+    getChargePointSettingsComponent() {
       console.debug(`loading charge point settings: ${this.chargePoint.name} (${this.chargePoint.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.chargePoint.type}/chargePoint.vue`),
         errorComponent: OpenwbChargePointConfigFallback,
       });
     },
-    myChargePointCommandsComponent() {
+    getChargePointCommandsComponent() {
       console.debug(`loading charge point commands: ${this.chargePoint.name} (${this.chargePoint.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.chargePoint.type}/commands.vue`),
         errorComponent: OpenwbChargePointCommandsFallback,
       });
     },
-  },
-  methods: {
     updateConfiguration(event) {
       this.$emit("update:configuration", event);
     },

--- a/src/components/devices/OpenwbConfigProxy.vue
+++ b/src/components/devices/OpenwbConfigProxy.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="myComponent"
+    :is="getComponent()"
     :device="device"
     :component="component"
     :configuration="component ? component.configuration : device.configuration"
@@ -24,8 +24,8 @@ export default {
     component: { type: Object, required: false, default: undefined },
   },
   emits: ["update:configuration"],
-  computed: {
-    myComponent() {
+  methods: {
+    getComponent() {
       console.debug(
         `loading component: ${this.device.name} (${this.device.type}) / ${this.component?.name} (${this.component?.type})`,
       );
@@ -41,8 +41,6 @@ export default {
         });
       }
     },
-  },
-  methods: {
     updateConfiguration(event) {
       this.$emit("update:configuration", event);
     },

--- a/src/components/display_themes/OpenwbDisplayThemeProxy.vue
+++ b/src/components/display_themes/OpenwbDisplayThemeProxy.vue
@@ -22,7 +22,7 @@
   </openwb-base-alert>
   <openwb-base-heading> Einstellungen für Display Theme "{{ displayTheme.name }}" </openwb-base-heading>
   <component
-    :is="myComponent"
+    :is="getDisplayThemeComponent()"
     :display-theme="displayTheme"
     @update:configuration="updateConfiguration($event)"
   />
@@ -47,16 +47,14 @@ export default {
     displayTheme: { type: Object, required: true },
   },
   emits: ["update:configuration"],
-  computed: {
-    myComponent() {
+  methods: {
+    getDisplayThemeComponent() {
       console.debug(`loading display theme: ${this.displayTheme.name} (${this.displayTheme.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.displayTheme.type}/displayTheme.vue`),
         errorComponent: OpenwbDisplayThemeFallback,
       });
     },
-  },
-  methods: {
     updateConfiguration(event) {
       this.$emit("update:configuration", event);
     },

--- a/src/components/electricity_tariffs/OpenwbElectricityTariffProxy.vue
+++ b/src/components/electricity_tariffs/OpenwbElectricityTariffProxy.vue
@@ -1,7 +1,7 @@
 <template>
   <openwb-base-heading> Einstellungen für Modul "{{ electricityTariff.name }}" </openwb-base-heading>
   <component
-    :is="myComponent"
+    :is="getTariffComponent()"
     :electricity-tariff="electricityTariff"
     @update:configuration="updateConfiguration($event)"
   />
@@ -17,16 +17,14 @@ export default {
     electricityTariff: { type: Object, required: true },
   },
   emits: ["update:configuration"],
-  computed: {
-    myComponent() {
+  methods: {
+    getTariffComponent() {
       console.debug(`loading electricity tariff: ${this.electricityTariff.name} (${this.electricityTariff.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.electricityTariff.type}/electricity_tariff.vue`),
         errorComponent: OpenwbElectricityTariffFallback,
       });
     },
-  },
-  methods: {
     updateConfiguration(event) {
       this.$emit("update:configuration", event);
     },

--- a/src/components/monitoring/OpenwbMonitoringProxy.vue
+++ b/src/components/monitoring/OpenwbMonitoringProxy.vue
@@ -1,7 +1,7 @@
 <template>
   <openwb-base-heading> Einstellungen für Modul "{{ monitoring.name }}" </openwb-base-heading>
   <component
-    :is="myComponent"
+    :is="getMonitoringComponent()"
     :monitoring="monitoring"
     @update:configuration="updateConfiguration($event)"
   />
@@ -17,16 +17,14 @@ export default {
     monitoring: { type: Object, required: true },
   },
   emits: ["update:configuration"],
-  computed: {
-    myComponent() {
+  methods: {
+    getMonitoringComponent() {
       console.debug(`loading monitoring: ${this.monitoring.name} (${this.monitoring.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.monitoring.type}/monitoring.vue`),
         errorComponent: OpenwbMonitoringFallback,
       });
     },
-  },
-  methods: {
     updateConfiguration(event) {
       this.$emit("update:configuration", event);
     },

--- a/src/components/ripple_control_receivers/OpenwbRippleControlReceiverProxy.vue
+++ b/src/components/ripple_control_receivers/OpenwbRippleControlReceiverProxy.vue
@@ -1,7 +1,7 @@
 <template>
   <openwb-base-heading> Einstellungen für RSE-Modul "{{ rippleControlReceiver.name }}" </openwb-base-heading>
   <component
-    :is="myComponent"
+    :is="getRippleControlReceiverComponent()"
     :ripple-control-receiver="rippleControlReceiver"
     @update:configuration="updateConfiguration($event)"
     @send-command="sendCommand($event)"
@@ -18,8 +18,8 @@ export default {
     rippleControlReceiver: { type: Object, required: true },
   },
   emits: ["update:configuration", "sendCommand"],
-  computed: {
-    myComponent() {
+  methods: {
+    getRippleControlReceiverComponent() {
       console.debug(
         `loading ripple control receiver: ${this.rippleControlReceiver.name} (${this.rippleControlReceiver.type})`,
       );
@@ -28,8 +28,6 @@ export default {
         errorComponent: OpenwbRippleControlReceiverFallback,
       });
     },
-  },
-  methods: {
     // event pass through
     updateConfiguration(event) {
       this.$emit("update:configuration", event);

--- a/src/components/vehicles/OpenwbVehicleProxy.vue
+++ b/src/components/vehicles/OpenwbVehicleProxy.vue
@@ -1,7 +1,7 @@
 <template>
   <openwb-base-heading> Einstellungen für SoC-Modul "{{ vehicle.name }}" </openwb-base-heading>
   <component
-    :is="myComponent"
+    :is="getVehicleComponent()"
     :vehicle-id="vehicleId"
     :vehicle="vehicle"
     @update:configuration="updateConfiguration($event)"
@@ -19,16 +19,14 @@ export default {
     vehicle: { type: Object, required: true },
   },
   emits: ["update:configuration"],
-  computed: {
-    myComponent() {
+  methods: {
+    getVehicleComponent() {
       console.debug(`loading vehicle: ${this.vehicle.name} (${this.vehicle.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.vehicle.type}/vehicle.vue`),
         errorComponent: OpenwbVehicleFallback,
       });
     },
-  },
-  methods: {
     updateConfiguration(event) {
       this.$emit("update:configuration", event);
     },

--- a/src/components/web_themes/OpenwbWebThemeProxy.vue
+++ b/src/components/web_themes/OpenwbWebThemeProxy.vue
@@ -21,7 +21,7 @@
   </openwb-base-alert>
   <openwb-base-heading> Einstellungen für Web Theme "{{ webTheme.name }}" </openwb-base-heading>
   <component
-    :is="myComponent"
+    :is="getThemeComponent()"
     :web-theme="webTheme"
     @update:configuration="updateConfiguration($event)"
   />
@@ -46,16 +46,14 @@ export default {
     webTheme: { type: Object, required: true },
   },
   emits: ["update:configuration"],
-  computed: {
-    myComponent() {
+  methods: {
+    getThemeComponent() {
       console.debug(`loading web theme: ${this.webTheme.name} (${this.webTheme.type})`);
       return defineAsyncComponent({
         loader: () => import(`./${this.webTheme.type}/webTheme.vue`),
         errorComponent: OpenwbWebThemeFallback,
       });
     },
-  },
-  methods: {
     updateConfiguration(event) {
       this.$emit("update:configuration", event);
     },

--- a/src/views/InstallAssistant.vue
+++ b/src/views/InstallAssistant.vue
@@ -11,7 +11,7 @@
       Wollen Sie den Assistenten wirklich vorzeitig beenden?
     </openwb-base-modal-dialog>
     <component
-      :is="myStepComponent"
+      :is="getInstallAssistantStepComponent()"
       @send-command="$emit('sendCommand', $event)"
       @save="$emit('save')"
       @reset="$emit('reset')"
@@ -37,21 +37,22 @@ export default {
       showEndAssistantModal: false,
     };
   },
-  computed: {
+  methods: {
     /**
      * Returns a dynamic component based on the current page of the install assistant.
      * The component is loaded asynchronously using `defineAsyncComponent` and the appropriate
      * InstallAssistantStep component is imported based on the value of `this.currentPage`.
+     * This is not a computed property because the component is loaded dynamically and
+     * should always be recomputed when the page changes.
      *
      * @returns {Component} The dynamically loaded component for the current page of the install assistant.
      */
-    myStepComponent() {
+    getInstallAssistantStepComponent() {
+      console.debug(`loading assistant page: ${this.currentPage}`);
       return defineAsyncComponent({
         loader: () => import(`../components/install_assistant/InstallAssistantStep${this.currentPage}.vue`),
       });
     },
-  },
-  methods: {
     /**
      * Switches the current page of the install assistant.
      *


### PR DESCRIPTION
Switching install assistant pages was broken after a debug log statement got removed. Switched from a computed property to a method as these are not cached and revalidated on every call.