### PR TITLE
Visibility secondary

### DIFF
--- a/src/components/devices/tesla/tesla/device.vue
+++ b/src/components/devices/tesla/tesla/device.vue
@@ -1,6 +1,21 @@
 <template>
   <div class="device-tesla">
     <openwb-base-heading> Einstellungen für Tesla </openwb-base-heading>
+    <openwb-base-alert subtype="danger">
+      <span style="font-weight: bold">
+        Tesla hat in der aktuellen Firmware-Version die lokale API der PowerWall abgeschaltet. </span
+      >Daher ist es mit dieser Firmware nicht mehr möglich, die PowerWall direkt auszulesen. Wir prüfen aktuell den
+      Zugriff über die Tesla-Server. Bis zur Umsetzung dieser Funktion ist es nicht möglich, die PowerWall lokal
+      auszulesen.<br />
+      <span style="font-weight: bold">
+        Wenn die lokale Abfrage bei Dir noch funktioniert, dann solltest Du die Firmware der PowerWall nicht
+        aktualisieren! </span
+      ><br />
+      Wir empfehlen, dass Du Tesla kontaktierst und Kritik an dieser Entscheidung mitteilst. Nur so können wir hoffen,
+      dass Tesla die lokale API wieder aktiviert. Mit der Cloud-API kommt es zwangsläufig zu Verzögerungen (Latenzen),
+      welche eine Regelung durch openWB erschweren. Weiterhin kommt es zu einem totalen Ausfall, wenn die
+      Internetverbindung gestört ist. Aus diesen Gründen ist eine lokale API immer vorzuziehen.
+    </openwb-base-alert>
     <openwb-base-text-input
       title="IP oder Hostname"
       subtype="host"

--- a/src/views/Chart.vue
+++ b/src/views/Chart.vue
@@ -1,107 +1,115 @@
 <template>
   <div class="chart">
-    <form name="chartForm">
-      <openwb-base-card
-        title="Filter"
-        :collapsible="true"
-        :collapsed="false"
-      >
-        <openwb-base-select-input
-          v-model="chartRange"
-          title="Zeitraum"
-          :options="[
-            { value: 'day', text: 'Tag' },
-            { value: 'month', text: 'Monat' },
-            { value: 'year', text: 'Jahr' },
-          ]"
-        />
-        <openwb-base-text-input
-          v-model="chartDate"
-          :title="dateInput.title"
-          :subtype="dateInput.type"
-          :min="dateInput.min"
-          :max="currentDate"
-          :show-quick-buttons="true"
-          @update:model-value="updateChart()"
-        />
-      </openwb-base-card>
-      <openwb-base-alert
-        v-if="!chartDataRead"
-        subtype="info"
-      >
-        Es wurden noch keine Daten abgerufen.
+    <div v-if="$store.state.mqtt['openWB/general/extern'] === true">
+      <openwb-base-alert subtype="info">
+        Die Auswertungen sind nicht verfügbar, solange sich diese openWB im Steuerungsmodus "secondary" befindet. Du
+        findest alle Auswertungen in der openWB, welche sich im Steuerungsmodus "primary" befindet.
       </openwb-base-alert>
-      <div v-else>
+    </div>
+    <div v-else>
+      <form name="chartForm">
+        <openwb-base-card
+          title="Filter"
+          :collapsible="true"
+          :collapsed="false"
+        >
+          <openwb-base-select-input
+            v-model="chartRange"
+            title="Zeitraum"
+            :options="[
+              { value: 'day', text: 'Tag' },
+              { value: 'month', text: 'Monat' },
+              { value: 'year', text: 'Jahr' },
+            ]"
+          />
+          <openwb-base-text-input
+            v-model="chartDate"
+            :title="dateInput.title"
+            :subtype="dateInput.type"
+            :min="dateInput.min"
+            :max="currentDate"
+            :show-quick-buttons="true"
+            @update:model-value="updateChart()"
+          />
+        </openwb-base-card>
         <openwb-base-alert
-          v-if="!chartDataHasEntries"
+          v-if="!chartDataRead"
           subtype="info"
         >
-          Es konnten keine Daten für diesen Zeitraum gefunden werden.
+          Es wurden noch keine Daten abgerufen.
         </openwb-base-alert>
         <div v-else>
-          <openwb-base-card
-            title="Diagramm"
-            :collapsible="true"
-            :collapsed="false"
+          <openwb-base-alert
+            v-if="!chartDataHasEntries"
+            subtype="info"
           >
-            <div class="openwb-chart">
-              <chartjs-line
-                ref="myChart"
-                :data="chartData"
-                :options="chartOptions"
-                @click="handleChartClick"
-              />
-            </div>
-          </openwb-base-card>
-          <openwb-base-card
-            title="Summen"
-            :collapsible="true"
-            :collapsed="true"
-          >
-            <div
-              v-for="(group, groupKey) in chartTotals"
-              :key="groupKey"
+            Es konnten keine Daten für diesen Zeitraum gefunden werden.
+          </openwb-base-alert>
+          <div v-else>
+            <openwb-base-card
+              title="Diagramm"
+              :collapsible="true"
+              :collapsed="false"
             >
-              <openwb-base-card
-                v-if="Object.keys(group).length > 0"
-                :collapsible="true"
-                :collapsed="true"
-                :subtype="getCardSubtype(groupKey)"
+              <div class="openwb-chart">
+                <chartjs-line
+                  ref="myChart"
+                  :data="chartData"
+                  :options="chartOptions"
+                  @click="handleChartClick"
+                />
+              </div>
+            </openwb-base-card>
+            <openwb-base-card
+              title="Summen"
+              :collapsible="true"
+              :collapsed="true"
+            >
+              <div
+                v-for="(group, groupKey) in chartTotals"
+                :key="groupKey"
               >
-                <template #header>
-                  <font-awesome-icon
-                    fixed-width
-                    :icon="getCardIcon(groupKey)"
-                  />
-                  {{ getTotalsLabel(groupKey) }}
-                </template>
-                <div
-                  v-for="(component, componentKey) in group"
-                  :key="componentKey"
+                <openwb-base-card
+                  v-if="Object.keys(group).length > 0"
+                  :collapsible="true"
+                  :collapsed="true"
+                  :subtype="getCardSubtype(groupKey)"
                 >
-                  <openwb-base-heading v-if="groupKey !== 'hc'">
-                    {{ getTotalsLabel(groupKey, componentKey) }}
-                  </openwb-base-heading>
-                  <div
-                    v-for="(measurement, measurementKey) in component"
-                    :key="measurementKey"
-                  >
-                    <openwb-base-text-input
-                      :title="getTotalsLabel(groupKey, componentKey, measurementKey)"
-                      readonly
-                      class="text-right"
-                      unit="kWh"
-                      :model-value="formatNumber(measurement / 1000, 3)"
+                  <template #header>
+                    <font-awesome-icon
+                      fixed-width
+                      :icon="getCardIcon(groupKey)"
                     />
+                    {{ getTotalsLabel(groupKey) }}
+                  </template>
+                  <div
+                    v-for="(component, componentKey) in group"
+                    :key="componentKey"
+                  >
+                    <openwb-base-heading v-if="groupKey !== 'hc'">
+                      {{ getTotalsLabel(groupKey, componentKey) }}
+                    </openwb-base-heading>
+                    <div
+                      v-for="(measurement, measurementKey) in component"
+                      :key="measurementKey"
+                    >
+                      <openwb-base-text-input
+                        :title="getTotalsLabel(groupKey, componentKey, measurementKey)"
+                        readonly
+                        class="text-right"
+                        unit="kWh"
+                        :model-value="formatNumber(measurement / 1000, 3)"
+                      />
+                    </div>
+                    <hr v-if="componentKey == 'all' && groupKey != 'hc'" />
                   </div>
-                  <hr v-if="componentKey == 'all' && groupKey != 'hc'" />
-                </div>
-              </openwb-base-card>
-            </div>
-          </openwb-base-card>
+                </openwb-base-card>
+              </div>
+            </openwb-base-card>
+          </div>
         </div>
-      </div>
-    </form>
+      </form>
+    </div>
   </div>
 </template>
 

--- a/src/views/CloudConfig.vue
+++ b/src/views/CloudConfig.vue
@@ -48,103 +48,7 @@
             </a>
             .
           </openwb-base-alert>
-          <openwb-base-text-input
-            v-model="newCloudData.username"
-            title="Benutzername"
-            required
-            subtype="user"
-            pattern="[a-zA-Z]+"
-            disabled
-          />
-          <openwb-base-text-input
-            v-model="newCloudData.email"
-            title="E-Mail"
-            required
-            subtype="email"
-            disabled
-          />
-          <openwb-base-button-group-input
-            v-model="newCloudData.partner"
-            disabled
-            title="Zugang für Partner"
-            :buttons="[
-              {
-                buttonValue: false,
-                text: 'Aus',
-                class: 'btn-outline-danger',
-              },
-              {
-                buttonValue: true,
-                text: 'An',
-                class: 'btn-outline-success',
-              },
-            ]"
-          >
-            <template #help>
-              Wenn diese openWB über einen Partner erworben wurde, kann hier ein Support-Zugang für diesen freigegeben
-              werden.
-            </template>
-          </openwb-base-button-group-input>
-          <openwb-base-array-input
-            v-if="newCloudData.partner"
-            title="Gültige Partner-IDs"
-            no-elements-message="Keine Partner-ID zugeordnet."
-            :model-value="$store.state.mqtt['openWB/system/mqtt/valid_partner_ids']"
-            @update:model-value="updateState('openWB/system/mqtt/valid_partner_ids', $event)"
-          >
-            <template #input-prefix>
-              <font-awesome-icon
-                fixed-width
-                :icon="['fas', 'user-gear']"
-              />
-            </template>
-            <template #element-prefix>
-              <font-awesome-icon
-                fixed-width
-                :icon="['fas', 'user-gear']"
-              />
-            </template>
-            <template #help>
-              Die Partner-ID erhältst Du von Deinem Installateur. Ist hier keine Partner-ID eingetragen, dann kann auch
-              niemand - trotz aktiviertem Zugang für Partner - über das Partner-Portal auf diese openWB zugreifen!
-            </template>
-          </openwb-base-array-input>
-          <template
-            v-if="
-              $store.state.mqtt['openWB/general/extern'] === false &&
-              $store.state.mqtt['openWB/system/dataprotection_acknowledged'] === true
-            "
-            #footer
-          >
-            <div class="row justify-content-center">
-              <!-- <openwb-base-click-button
-                class="col-4"
-                :class="
-                  enableNewCloudButton
-                    ? 'btn-success'
-                    : 'btn-outline-success'
-                "
-                :disabled="!enableNewCloudButton"
-                @buttonClicked="createCloud"
-              >
-                Zugang erstellen
-              </openwb-base-click-button> -->
-              <openwb-base-click-button
-                class="col-4 btn-outline-success"
-                disabled
-              >
-                Zugang erstellen
-              </openwb-base-click-button>
-            </div>
-          </template>
         </openwb-base-card>
-        <openwb-base-alert
-          v-if="!enableNewCloudButton"
-          subtype="info"
-          class="mb-2"
-        >
-          Der neue Zugang wird eingerichtet. Dieser Vorgang kann bis zu einer Minute dauern. Bitte warten.
-        </openwb-base-alert>
       </form>
       <form
         v-if="!cloudBridgeKey"
@@ -209,10 +113,7 @@
             </template>
           </openwb-base-array-input>
           <template
-            v-if="
-              $store.state.mqtt['openWB/general/extern'] === false &&
-              $store.state.mqtt['openWB/system/dataprotection_acknowledged'] === true
-            "
+            v-if="$store.state.mqtt['openWB/system/dataprotection_acknowledged'] === true"
             #footer
           >
             <div class="row justify-content-center">

--- a/src/views/DataManagement.vue
+++ b/src/views/DataManagement.vue
@@ -213,7 +213,7 @@
         </form>
       </openwb-base-card>
       <openwb-base-card
-        v-if="!installAssistantActive"
+        v-if="!installAssistantActive && !$store.state.mqtt['openWB/general/extern']"
         title="Datenübernahme"
         subtype="success"
         :collapsible="true"
@@ -450,6 +450,7 @@ export default {
   data() {
     return {
       mqttTopicsToSubscribe: [
+        "openWB/general/extern",
         "openWB/system/configurable/backup_clouds",
         "openWB/system/configurable/monitoring",
         "openWB/system/backup_cloud/config",

--- a/src/views/GeneralChargeConfig.vue
+++ b/src/views/GeneralChargeConfig.vue
@@ -177,91 +177,98 @@
               @update:configuration="updateConfiguration('openWB/optional/et/provider', $event)"
             />
           </div>
-        </div>
-        <hr />
-        <openwb-base-heading> Speicher-Entladung ins Fahrzeug steuern </openwb-base-heading>
-        <div v-if="$store.state.mqtt['openWB/bat/get/power_limit_controllable'] === true">
-          <openwb-base-button-group-input
-            title="Speicher-Entladung"
-            :buttons="[
-              {
-                buttonValue: 'no_limit',
-                text: 'immer',
-              },
-              {
-                buttonValue: 'limit_stop',
-                text: 'gesperrt, wenn Fahrzeug lädt',
-              },
-              {
-                buttonValue: 'limit_to_home_consumption',
-                text: 'für Hausverbrauch',
-              },
-            ]"
-            :model-value="$store.state.mqtt['openWB/bat/config/power_limit_mode']"
-            @update:model-value="updateState('openWB/bat/config/power_limit_mode', $event)"
-          >
-            <template #help>
-              Wenn das Entladen des Speichers immer erlaubt ist, wird das Fahrzeug aus dem Speicher geladen anstatt
-              Strom aus dem Netz zu beziehen. <br />
-              Im Modus "gesperrt, wenn Fahrzeug lädt", wird die Entladung nur zugelassen, wenn alle Fahrzeuge im Modus
-              PV-Laden ohne Mindeststrom oder Zielladen mit PV-Überschuss laden.<br />
-              Wenn das Entladen des Speichers auf den Hausverbrauch begrenzt ist und mindestens Fahrzeuge nicht im Modus
-              PV-Laden ohne Mindeststrom oder Zielladen lädt, wird die Entladung des Speichers in Höhe des
-              Hausverbrauchs zugelassen. Kann die Entladung am Speicher nur komplett gesperrt werden, verhält sich diese
-              Einstellung wie "gesperrt, wenn Fahrzeug lädt".<br />
-              Diese Einstellung übersteuert ggf die Einstellungen zur Speicher-Beachtung im Modus PV-Laden.
-            </template>
-          </openwb-base-button-group-input>
-        </div>
-        <div v-else>
-          <openwb-base-alert subtype="info">
-            Die Speicher-Entladung ins Fahrzeug kann nicht gesteuert werden, da die Entladeleistung nicht an den/die
-            konfigurierten Speicher übergeben werden kann.
-          </openwb-base-alert>
+          <hr />
+          <openwb-base-heading> Speicher-Entladung ins Fahrzeug steuern </openwb-base-heading>
+          <div v-if="$store.state.mqtt['openWB/bat/get/power_limit_controllable'] === true">
+            <openwb-base-button-group-input
+              title="Speicher-Entladung"
+              :buttons="[
+                {
+                  buttonValue: 'no_limit',
+                  text: 'immer',
+                },
+                {
+                  buttonValue: 'limit_stop',
+                  text: 'gesperrt, wenn Fahrzeug lädt',
+                },
+                {
+                  buttonValue: 'limit_to_home_consumption',
+                  text: 'für Hausverbrauch',
+                },
+              ]"
+              :model-value="$store.state.mqtt['openWB/bat/config/power_limit_mode']"
+              @update:model-value="updateState('openWB/bat/config/power_limit_mode', $event)"
+            >
+              <template #help>
+                Wenn das Entladen des Speichers immer erlaubt ist, wird das Fahrzeug aus dem Speicher geladen anstatt
+                Strom aus dem Netz zu beziehen. <br />
+                Im Modus "gesperrt, wenn Fahrzeug lädt", wird die Entladung nur zugelassen, wenn alle Fahrzeuge im Modus
+                PV-Laden ohne Mindeststrom oder Zielladen mit PV-Überschuss laden.<br />
+                Wenn das Entladen des Speichers auf den Hausverbrauch begrenzt ist und mindestens Fahrzeuge nicht im
+                Modus PV-Laden ohne Mindeststrom oder Zielladen lädt, wird die Entladung des Speichers in Höhe des
+                Hausverbrauchs zugelassen. Kann die Entladung am Speicher nur komplett gesperrt werden, verhält sich
+                diese Einstellung wie "gesperrt, wenn Fahrzeug lädt".<br />
+                Diese Einstellung übersteuert ggf die Einstellungen zur Speicher-Beachtung im Modus PV-Laden.
+              </template>
+            </openwb-base-button-group-input>
+          </div>
+          <div v-else>
+            <openwb-base-alert subtype="info">
+              Die Speicher-Entladung ins Fahrzeug kann nicht gesteuert werden, da die Entladeleistung nicht an den/die
+              konfigurierten Speicher übergeben werden kann.
+            </openwb-base-alert>
+          </div>
         </div>
       </openwb-base-card>
       <openwb-base-card title="OCPP Anbindung">
-        <openwb-base-button-group-input
-          title="OCPP aktivieren"
-          :buttons="[
-            {
-              buttonValue: false,
-              text: 'Nein',
-              class: 'btn-outline-danger',
-            },
-            {
-              buttonValue: true,
-              text: 'Ja',
-              class: 'btn-outline-success',
-            },
-          ]"
-          :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.active"
-          @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'active')"
-        />
-        <div v-if="$store.state.mqtt['openWB/optional/ocpp/config']?.active === true">
+        <div v-if="$store.state.mqtt['openWB/general/extern'] === true">
           <openwb-base-alert subtype="info">
-            Die Ladepunkte übermitteln den ID-Tag, Heartbeat und den Zählerstand zum Zeitpunkt des Ansteckens,
-            Absteckens und alle 5 Minuten. Eine Steuerung per OCPP ist nicht möglich.<br />
-            Alle Ladepunkte, die ihre Daten an das OCPP-Backend übermitteln sollen, müssen zunächst im OCPP-Backend
-            angelegt werden. Die dort eingetragene Chargebox ID muss in der openWB in den Einstellungen des Ladepunkts
-            eingetragen werden.
+            Diese Einstellungen sind nicht verfügbar, solange sich diese openWB im Steuerungsmodus "secondary" befindet.
           </openwb-base-alert>
-          <openwb-base-text-input
-            title="URL des OCPP-Backends"
-            subtype="host"
-            :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.url"
-            @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'url')"
-          />
-          <openwb-base-select-input
-            title="Version"
-            not-selected="Bitte auswählen"
-            :options="[
-              { value: 'ocpp1.6', text: 'OCPP 1.6' },
-              { value: 'ocpp2.0.1', text: 'OCPP 2.0.1' },
+        </div>
+        <div v-else>
+          <openwb-base-button-group-input
+            title="OCPP aktivieren"
+            :buttons="[
+              {
+                buttonValue: false,
+                text: 'Nein',
+                class: 'btn-outline-danger',
+              },
+              {
+                buttonValue: true,
+                text: 'Ja',
+                class: 'btn-outline-success',
+              },
             ]"
-            :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.version"
-            @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'version')"
+            :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.active"
+            @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'active')"
           />
+          <div v-if="$store.state.mqtt['openWB/optional/ocpp/config']?.active === true">
+            <openwb-base-alert subtype="info">
+              Die Ladepunkte übermitteln den ID-Tag, Heartbeat und den Zählerstand zum Zeitpunkt des Ansteckens,
+              Absteckens und alle 5 Minuten. Eine Steuerung per OCPP ist nicht möglich.<br />
+              Alle Ladepunkte, die ihre Daten an das OCPP-Backend übermitteln sollen, müssen zunächst im OCPP-Backend
+              angelegt werden. Die dort eingetragene Chargebox ID muss in der openWB in den Einstellungen des Ladepunkts
+              eingetragen werden.
+            </openwb-base-alert>
+            <openwb-base-text-input
+              title="URL des OCPP-Backends"
+              subtype="host"
+              :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.url"
+              @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'url')"
+            />
+            <openwb-base-select-input
+              title="Version"
+              not-selected="Bitte auswählen"
+              :options="[
+                { value: 'ocpp1.6', text: 'OCPP 1.6' },
+                { value: 'ocpp2.0.1', text: 'OCPP 2.0.1' },
+              ]"
+              :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.version"
+              @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'version')"
+            />
+          </div>
         </div>
       </openwb-base-card>
       <openwb-base-submit-buttons

--- a/src/views/OptionalComponents.vue
+++ b/src/views/OptionalComponents.vue
@@ -2,6 +2,35 @@
   <div class="optionalComponents">
     <form name="optionalComponentsForm">
       <openwb-base-card title="Identifikation">
+        <openwb-base-button-group-input
+          title="Identifikation aktivieren"
+          :model-value="$store.state.mqtt['openWB/optional/rfid/active']"
+          :buttons="[
+            {
+              buttonValue: false,
+              text: 'Aus',
+              class: 'btn-outline-danger',
+            },
+            {
+              buttonValue: true,
+              text: 'An',
+              class: 'btn-outline-success',
+            },
+          ]"
+          @update:model-value="updateState('openWB/optional/rfid/active', $event)"
+        >
+          <template #help>
+            Die Identifikation kann zum Entsperren von Ladepunkten und/oder zur Zuordnung von Fahrzeugen genutzt werden
+            und kann auf mehreren Wegen erfolgen:
+            <ul>
+              <li>Über einen in der openWB verbauten RFID-Reader (optional, z.B. anhand des Lieferscheins prüfen).</li>
+              <li>
+                Durch die automatische Erkennung an einer openWB Pro (muss in den Einstellungen aktiviert werden).
+              </li>
+              <li>Durch manuelle Eingabe einer ID am Display einer openWB.</li>
+            </ul>
+          </template>
+        </openwb-base-button-group-input>
         <div v-if="$store.state.mqtt['openWB/general/extern'] === true">
           <openwb-base-alert subtype="info">
             Weitere Einstellungen sind nicht verfügbar, solange sich diese openWB im Steuerungsmodus "secondary"
@@ -9,37 +38,6 @@
           </openwb-base-alert>
         </div>
         <div v-else>
-          <openwb-base-button-group-input
-            title="Identifikation aktivieren"
-            :model-value="$store.state.mqtt['openWB/optional/rfid/active']"
-            :buttons="[
-              {
-                buttonValue: false,
-                text: 'Aus',
-                class: 'btn-outline-danger',
-              },
-              {
-                buttonValue: true,
-                text: 'An',
-                class: 'btn-outline-success',
-              },
-            ]"
-            @update:model-value="updateState('openWB/optional/rfid/active', $event)"
-          >
-            <template #help>
-              Die Identifikation kann zum Entsperren von Ladepunkten und/oder zur Zuordnung von Fahrzeugen genutzt
-              werden und kann auf mehreren Wegen erfolgen:
-              <ul>
-                <li>
-                  Über einen in der openWB verbauten RFID-Reader (optional, z.B. anhand des Lieferscheins prüfen).
-                </li>
-                <li>
-                  Durch die automatische Erkennung an einer openWB Pro (muss in den Einstellungen aktiviert werden).
-                </li>
-                <li>Durch manuelle Eingabe einer ID am Display einer openWB.</li>
-              </ul>
-            </template>
-          </openwb-base-button-group-input>
           <div v-if="$store.state.mqtt['openWB/optional/rfid/active'] === true">
             <openwb-base-alert
               subtype="info"

--- a/src/views/PVChargeConfig.vue
+++ b/src/views/PVChargeConfig.vue
@@ -65,13 +65,9 @@
             <template #help> Obere Grenze des Regelbereichs. </template>
           </openwb-base-number-input>
           <hr />
-          <openwb-base-alert subtype="danger">
+          <openwb-base-alert :subtype="chargingSwitchRange < 1400 ? 'danger' : 'info'">
             Die Differenzleistung zw. Ein- und Abschaltschwelle sollte mind. 1.4kW (230V x 6A) betragen. (Konfiguriert:
-            {{
-              ($store.state.mqtt["openWB/general/chargemode_config/pv_charging/switch_on_threshold"] +
-                $store.state.mqtt["openWB/general/chargemode_config/pv_charging/switch_off_threshold"]) /
-              1000
-            }}&nbsp;kW)
+            {{ chargingSwitchRange / 1000 }}&nbsp;kW)
           </openwb-base-alert>
           <openwb-base-number-input
             title="Einschaltschwelle"
@@ -454,6 +450,14 @@ export default {
           case "individual":
             break;
         }
+      },
+    },
+    chargingSwitchRange: {
+      get() {
+        return (
+          this.$store.state.mqtt["openWB/general/chargemode_config/pv_charging/switch_on_threshold"] +
+          this.$store.state.mqtt["openWB/general/chargemode_config/pv_charging/switch_off_threshold"]
+        );
       },
     },
     batMode: {

--- a/src/views/Status.vue
+++ b/src/views/Status.vue
@@ -41,7 +41,7 @@
       :vehicle-name="vehicleName"
     />
     <!-- electricity tariff -->
-    <electricity-tariff-card />
+    <electricity-tariff-card v-if="$store.state.mqtt['openWB/general/extern'] === false" />
     <!-- ripple-control-receiver -->
     <ripple-control-receiver-card />
   </div>


### PR DESCRIPTION
- add warning for tesla device about disabled local api
- disable charge-log in secondary mode
- disable charts in secondary mode
- remove "new cloud" code
- allow cloud connect in secondary mode
- disable data import in secondary mode
- disable active battery control in secondary mode
- disable ocpp connection in secondary mode
- display identification option in secondary mode
- format info about pv smitch on/off range as warning only if range is too small
- hide tariff status card in secondary mode