### PR TITLE
[ADD] Integration Battery Index for SolarEdge Batteries

### DIFF
--- a/src/components/devices/solaredge/solaredge/bat.vue
+++ b/src/components/devices/solaredge/solaredge/bat.vue
@@ -9,6 +9,17 @@
       max="255"
       @update:model-value="updateConfiguration($event, 'configuration.modbus_id')"
     />
+    <openwb-base-alert subtype="info">
+      Hierfür muss eine zweite Batterie an einem Wechselrichter angeschlossen sein. Im Normalfall immer 1 ansonsten 2 wenn es 
+      sich um die zweite Batterie handelt.
+    </openwb-base-alert>
+    <openwb-base-number-input
+      title="SolarEdge-Batterie-Index"
+      :model-value="component.configuration.battery_index"
+      min="1"
+      max="2"
+      @update:model-value="updateConfiguration($event, 'configuration.battery_index')"
+    />
   </div>
 </template>
 

--- a/src/components/devices/solaredge/solaredge/bat.vue
+++ b/src/components/devices/solaredge/solaredge/bat.vue
@@ -9,17 +9,17 @@
       max="255"
       @update:model-value="updateConfiguration($event, 'configuration.modbus_id')"
     />
-    <openwb-base-alert subtype="info">
-      Hierfür muss eine zweite Batterie an einem Wechselrichter angeschlossen sein. Im Normalfall immer 1 ansonsten 2 wenn es 
-      sich um die zweite Batterie handelt.
-    </openwb-base-alert>
     <openwb-base-number-input
       title="SolarEdge-Batterie-Index"
       :model-value="component.configuration.battery_index"
       min="1"
       max="2"
       @update:model-value="updateConfiguration($event, 'configuration.battery_index')"
-    />
+    >
+      <template #help>
+      Wenn eine zweite Batterie am Wechselrichter angeschlossen ist, hier den Index 2 eintagen. Im Normalfall immer 1 eintragen.
+      </template>
+    </openwb-base-number-input>
   </div>
 </template>
 

--- a/src/components/devices/solaredge/solaredge/bat.vue
+++ b/src/components/devices/solaredge/solaredge/bat.vue
@@ -17,7 +17,7 @@
       @update:model-value="updateConfiguration($event, 'configuration.battery_index')"
     >
       <template #help>
-      Wenn eine zweite Batterie am Wechselrichter angeschlossen ist, hier den Index 2 eintagen. Im Normalfall immer 1 eintragen.
+        Wenn eine zweite Batterie am Wechselrichter angeschlossen ist, hier den Index 2 eintagen. Im Normalfall immer 1 eintragen.
       </template>
     </openwb-base-number-input>
   </div>


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?t=9875

Uses new registers from solaredge specification.
https://forum.iobroker.net/assets/uploads/files/1709136209375-decimal-power-control-open-protocol-for-solaredge-inverters.pdf

Similar to the handling here:
https://github.com/WillCodeForCats/solaredge-modbus-multi/blob/main/custom_components/solaredge_modbus_multi/const.py#L159