### PR TITLE
enhanced texts

### DIFF
--- a/src/components/io_actions/controllable_consumers/dimming/io_action.vue
+++ b/src/components/io_actions/controllable_consumers/dimming/io_action.vue
@@ -8,7 +8,7 @@
     title="maximale Bezugsleistung"
     unit="kW"
     min="0"
-    step="0.1"
+    step="0.01"
     required
     :disabled="Object.keys(value[0].input_matrix).length > 0 ? false : true"
     :model-value="ioAction?.configuration.max_import_power / 1000"
@@ -28,7 +28,12 @@
       Bitte die Ladepunkte und/oder digitale Ausgänge auswählen, welche berücksichtigt werden sollen. Es können mehrere
       Einträge ausgewählt werden. Bei steuerbaren Verbrauchseinrichtungen, die über einen digitalen Ausgang angesteuert
       werden, wird eine Leistung von 4,2 kW bei aktiver Dimmung angenommen. Ladepunkte werden so gesteuert, dass die
-      angegebene Leistung am EVU-Punkt nicht überschritten wird. Dadurch wird eigene PV-Erzeugung verrechnet.
+      angegebene Leistung am EVU-Punkt nicht überschritten wird. Eigene PV-Erzeugung und vorhandene Speicher werden
+      berücksichtigt und zusätzlich genutzt.<br />
+      Zugeordnete digitale Ausgänge werden im nicht gedimmten Zustand aktiviert und im gedimmten Zustand deaktiviert. So
+      ist sichergestellt, dass bei einem Verbindungsabbruch oder einem Ausfall der Steuerung die Verbraucher nicht
+      ungewollt mit voller Leistung betrieben werden. Ein mit "NO" bezeichneter digitaler Ausgang ist also für den nicht
+      gedimmten Zustand geschlossen und bei aktivierter Dimmung geöffnet.
     </template>
   </openwb-base-select-input>
 </template>

--- a/src/components/status/IoDeviceCard.vue
+++ b/src/components/status/IoDeviceCard.vue
@@ -73,7 +73,7 @@
         >
           {{ key }}:
           <font-awesome-icon
-            :title="getTitle(value)"
+            :title="getActionTitle(value)"
             :icon="getIcon(value)"
             class="fa-fw"
           />

--- a/src/views/LoadManagementConfig.vue
+++ b/src/views/LoadManagementConfig.vue
@@ -12,6 +12,10 @@
           </openwb-base-alert>
         </div>
         <div v-else>
+          <openwb-base-alert subtype="info">
+            Die Konfiguration für die externe Steuerung durch den Netzbetreiber (RSE, EMS, §14a) erfolgt in den
+            <router-link to="/IoConfiguration">Einstellungen der Ein-/Ausgänge</router-link> im Bereich der Aktionen.
+          </openwb-base-alert>
           <openwb-base-button-group-input
             title="Fahrzeuge, die nicht mit Sollstrom laden"
             :buttons="[


### PR DESCRIPTION
- Dimmen per EMS: Bezugsleistung mit zwei Nachkommastellen
- Hilfetext anhand Rückmeldungen angepasst
- Tooltip der Ausgänge im Status angepasst: offen/geschlossen -> aktiv/inaktiv
- Im Lastmanagement einen Hinweis mit Link zu den Ein-/Ausgängen ergänzt