### PR TITLE
limit nominal difference to 5A

### DIFF
--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -505,6 +505,8 @@
             <openwb-base-number-input
               title="Erlaubte Stromabweichung"
               :step="0.1"
+              :min="0"
+              :max="5"
               unit="A"
               :model-value="template.nominal_difference"
               @update:model-value="updateState(key, $event, 'nominal_difference')"


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?t=10061
Wenn bei der erlaubten Stromabweichung zu große Werte eingestellt werden, funktioniert die Umschaltung, berücksichtigung nicht ladender Fahrzeuge, etc nicht richtig. Es sollte die Abweichung des Fahrzeugs vom angegebenen Strom eingetragen werden.