### PR TITLE
fix domain pattern

### DIFF
--- a/src/components/OpenwbBaseTextInput.vue
+++ b/src/components/OpenwbBaseTextInput.vue
@@ -312,8 +312,7 @@ export default {
     hostPattern() {
       const ipPattern = "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
       const hostOnlyPattern = "^(?=.*[a-zA-Z].*$)([a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])$";
-      const domainPattern =
-        "^((?=[^.]*[a-zA-Z][^.]*\\.)([a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9]\\.))+((?=[^.]*[a-zA-Z].*$)([a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9]))$";
+      const domainPattern = "^(https?:\\/\\/)?((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,}$";
       return `(${ipPattern})|(${hostOnlyPattern})|(${domainPattern})`;
     },
   },


### PR DESCRIPTION
Das neue Pattern validiert folgende Eingaben korrekt:
✅ https://example.com
✅ http://example.com
✅ https://sub.example.com
✅ http://sub-domain.example.com
✅ example.com (ohne Protokoll)
✅ sub.example.com (ohne Protokoll)
❌ -invalid.example.com (ungültig, da Subdomain mit Bindestrich beginnt)
❌ invalid-.example.com (ungültig, da Subdomain mit Bindestrich endet)
❌ http://example (ungültig, da TLD mindestens zwei Buchstaben haben muss)

Das alte Pattern validiert die Domain https://openwb-backup.wb-solution.de für die Nextcloud-Backup-Cloud nicht.