### PR TITLE
Koala - make standard vehicle optional

### DIFF
--- a/src/components/web_themes/koala/webTheme.vue
+++ b/src/components/web_themes/koala/webTheme.vue
@@ -1,5 +1,27 @@
 <template>
   <div class="web-theme-koala">
+    <openwb-base-button-group-input
+      title="Standard-Fahrzeug ausblenden"
+      :buttons="[
+        {
+          buttonValue: false,
+          text: 'Nein',
+          class: 'btn-outline-danger',
+        },
+        {
+          buttonValue: true,
+          text: 'Ja',
+          class: 'btn-outline-success',
+        },
+      ]"
+      :model-value="webTheme.configuration.hide_standard_vehicle"
+      @update:model-value="updateConfiguration($event, 'configuration.hide_standard_vehicle')"
+    >
+      <template #help>
+        Legt fest, ob das Standardfahrzeug im Fahrzeugkarten- bzw. Ladepunkt-Fahrzeugauswahlmenü ausgeblendet wird.
+      </template>
+    </openwb-base-button-group-input>
+    <hr />
     <openwb-base-range-input
       title="Zeitfenster Verlaufsdiagramm"
       :min="15"
@@ -13,6 +35,7 @@
         Das Zeitfenster für das Verlaufsdiagramm wird auf die hier eingestellte Anzahl Minuten beschränkt.
       </template>
     </openwb-base-range-input>
+    <hr />
     <openwb-base-number-input
       title="Ladepunkt Kartenansicht Grenzwert"
       :min="0"


### PR DESCRIPTION
Gibt den Nutzern die Möglichkeit, das Standardfahrzeug aus der Benutzeroberfläche zu entfernen.
<img width="1155" height="667" alt="Bildschirmfoto 2025-07-31 um 09 11 00" src="https://github.com/user-attachments/assets/e3f2f2e2-e039-4936-9e7f-e3509b3431e5" />
