### PR TITLE
Koala - Add user defined slide order for top carousel.

### DIFF
--- a/src/components/OpenwbNestedList.vue
+++ b/src/components/OpenwbNestedList.vue
@@ -33,8 +33,10 @@
           </span> -->
         </div>
         <openwb-nested-list
+          v-if="nesting && element.children"
           v-model="element.children"
           :labels="labels"
+          :nesting="nesting"
         />
       </li>
     </template>
@@ -65,6 +67,7 @@ export default {
   props: {
     list: { type: Object, required: false, default: undefined },
     labels: { type: Object, required: false, default: undefined },
+    nesting: { type: Boolean, default: true },
   },
   methods: {
     classes(element) {

--- a/src/components/OpenwbSortableList.vue
+++ b/src/components/OpenwbSortableList.vue
@@ -15,6 +15,7 @@
       v-if="value !== undefined"
       v-model="value"
       :labels="labels"
+      :nesting="nesting"
     />
     <div v-else>Warte auf Daten...</div>
   </openwb-base-setting-element>
@@ -35,6 +36,7 @@ export default {
     title: { type: String, required: false, default: "" },
     modelValue: { type: Array, required: false, default: undefined },
     labels: { type: Object, default: undefined },
+    nesting: { type: Boolean, default: true },
   },
   emits: ["update:modelValue"],
   computed: {

--- a/src/components/web_themes/koala/webTheme.vue
+++ b/src/components/web_themes/koala/webTheme.vue
@@ -38,11 +38,11 @@
     <hr />
     <sortable-list
       v-model="slideOrderList"
-      title="Reihenfolge der Slides im Karussell"
+      title="Oberer Infobereich"
       :labels="numberedSlideLabels"
       :nesting="false"
     >
-      <template #help> Legt die Reihenfolge der Slides im oberen Karussell fest. </template>
+      <template #help> Anordnung/Reihenfolge des oberen Informationsbereiches. </template>
     </sortable-list>
     <hr />
     <openwb-base-number-input

--- a/src/components/web_themes/koala/webTheme.vue
+++ b/src/components/web_themes/koala/webTheme.vue
@@ -39,7 +39,7 @@
     <sortable-list
       v-model="slideOrderList"
       title="Reihenfolge der Slides im Karussell"
-      :labels="slideLabels"
+      :labels="numberedSlideLabels"
       :nesting="false"
     >
       <template #help> Legt die Reihenfolge der Slides im oberen Karussell fest. </template>
@@ -127,6 +127,15 @@ export default {
     SortableList,
   },
   mixins: [WebThemeConfigMixin],
+  data() {
+    return {
+      slideLabels: {
+        daily_totals: "Tageswerte",
+        history_chart: "Verlaufsdiagramm",
+        flow_diagram: "Energieflussdiagramm",
+      },
+    };
+  },
   computed: {
     slideOrderList: {
       get() {
@@ -142,12 +151,11 @@ export default {
         this.updateConfiguration(updatedSlideOrder, "configuration.top_carousel_slide_order");
       },
     },
-    slideLabels() {
-      return {
-        daily_totals: "Tageswerte",
-        history_chart: "Verlaufsdiagramm",
-        flow_diagram: "Energieflussdiagramm",
-      };
+    numberedSlideLabels() {
+      return this.slideOrderList.reduce((result, item, index) => {
+        result[item.id] = `${index + 1}. ${this.slideLabels[item.id] || item.id}`;
+        return result;
+      }, {});
     },
   },
 };

--- a/src/components/web_themes/koala/webTheme.vue
+++ b/src/components/web_themes/koala/webTheme.vue
@@ -36,6 +36,15 @@
       </template>
     </openwb-base-range-input>
     <hr />
+    <sortable-list
+      v-model="slideOrderList"
+      title="Reihenfolge der Slides im Karussell"
+      :labels="slideLabels"
+      :nesting="false"
+    >
+      <template #help> Legt die Reihenfolge der Slides im oberen Karussell fest. </template>
+    </sortable-list>
+    <hr />
     <openwb-base-number-input
       title="Ladepunkt Kartenansicht Grenzwert"
       :min="0"
@@ -110,9 +119,36 @@
 
 <script>
 import WebThemeConfigMixin from "../WebThemeConfigMixin.vue";
+import SortableList from "../../OpenwbSortableList.vue";
 
 export default {
   name: "WebThemeKoala",
+  components: {
+    SortableList,
+  },
   mixins: [WebThemeConfigMixin],
+  computed: {
+    slideOrderList: {
+      get() {
+        const slideOrder = this.webTheme.configuration.top_carousel_slide_order || [
+          "flow_diagram",
+          "history_chart",
+          "daily_totals",
+        ];
+        return slideOrder.map((id) => ({ id }));
+      },
+      set(newList) {
+        const updatedSlideOrder = newList.map((item) => item.id);
+        this.updateConfiguration(updatedSlideOrder, "configuration.top_carousel_slide_order");
+      },
+    },
+    slideLabels() {
+      return {
+        daily_totals: "Tageswerte",
+        history_chart: "Verlaufsdiagramm",
+        flow_diagram: "Energieflussdiagramm",
+      };
+    },
+  },
 };
 </script>


### PR DESCRIPTION
Der Benutzer kann die Reihenfolge, in der die Folien angezeigt werden, per Drag-and-Drop festlegen.
Konfiguration im Core-Repository PR2860 (Koala - Add new slide daily totals to top carousel) hinzugefügt.<img width="1120" height="646" alt="Bildschirmfoto 2025-10-27 um 16 20 04" src="https://github.com/user-attachments/assets/103d7a58-08b5-4dfd-9ea2-f17daaf982d2" />
