### PR TITLE
Update add/remove time/scheduled plan backend commands

### DIFF
--- a/src/components/vehicles/ChargeTemplateScheduledChargingPlan.vue
+++ b/src/components/vehicles/ChargeTemplateScheduledChargingPlan.vue
@@ -407,7 +407,7 @@ export default {
     copyPlan() {
       this.$emit("sendCommand", {
         command: "addChargeTemplateSchedulePlan",
-        data: { template: this.templateId, copy: this.modelValue.id },
+        data: { template: this.templateId, changed_in_theme: false, copy: this.modelValue.id },
       });
     },
     removePlanModal() {
@@ -418,7 +418,7 @@ export default {
       if (event == "confirm") {
         this.$emit("sendCommand", {
           command: "removeChargeTemplateSchedulePlan",
-          data: { template: this.templateId, plan: this.modelValue.id },
+          data: { template: this.templateId, plan: this.modelValue.id, changed_in_theme: false },
         });
       }
     },

--- a/src/components/vehicles/ChargeTemplateTimeChargingPlan.vue
+++ b/src/components/vehicles/ChargeTemplateTimeChargingPlan.vue
@@ -287,7 +287,7 @@ export default {
     copyPlan() {
       this.$emit("sendCommand", {
         command: "addChargeTemplateTimeChargingPlan",
-        data: { template: this.templateId, copy: this.modelValue.id },
+        data: { template: this.templateId, changed_in_theme: false, copy: this.modelValue.id },
       });
     },
     removePlanModal() {
@@ -298,7 +298,7 @@ export default {
       if (event == "confirm") {
         this.$emit("sendCommand", {
           command: "removeChargeTemplateTimeChargingPlan",
-          data: { template: this.templateId, plan: this.modelValue.id },
+          data: { template: this.templateId, plan: this.modelValue.id, changed_in_theme: false },
         });
       }
     },

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -1652,14 +1652,14 @@ export default {
     addChargeTemplateSchedulePlan(templateId) {
       this.$emit("sendCommand", {
         command: "addChargeTemplateSchedulePlan",
-        data: { template: templateId },
+        data: { template: templateId, changed_in_theme: false },
       });
     },
     /* charge template time charging plan management */
     addChargeTemplateTimeChargingPlan(templateId) {
       this.$emit("sendCommand", {
         command: "addChargeTemplateTimeChargingPlan",
-        data: { template: templateId },
+        data: { template: templateId, changed_in_theme: false },
       });
     },
     openActiveChargeModeCard(templateKey, activeMode) {


### PR DESCRIPTION
Bei den Backend-Befehle:

- addChargeTemplateSchedulePlan
- removeChargeTemplateSchedulePlan
- addChargeTemplateTimeChargingPlan
- removeChargeTemplateTimeChargingPlan

wird in data Objekt :   "changed_in_theme: false"  übergeben um zu entscheiden ob der Befehl 
von den Einstellungen oder Themes kommt

(Koala - Add Input dialog for editing scheduled and time plans #2893)