### PR TITLE
Charging plans adjust input oder to match Koala theme

### DIFF
--- a/src/components/vehicles/ChargeTemplateScheduledChargingPlan.vue
+++ b/src/components/vehicles/ChargeTemplateScheduledChargingPlan.vue
@@ -86,7 +86,7 @@
     />
     <openwb-base-text-input
       v-model="plan.time"
-      title="Ziel-Uhrzeit"
+      title="Ziel-Termin"
       subtype="time"
     >
       <template #help>
@@ -94,6 +94,110 @@
         Energiemenge BEREITS ERREICHT haben soll.
       </template>
     </openwb-base-text-input>
+    <openwb-base-button-group-input
+      v-model="plan.frequency.selected"
+      title="Wiederholungen"
+      :buttons="[
+        {
+          buttonValue: 'once',
+          text: 'Einmalig',
+          class: 'btn-outline-info',
+        },
+        {
+          buttonValue: 'daily',
+          text: 'Täglich',
+          class: 'btn-outline-info',
+        },
+        {
+          buttonValue: 'weekly',
+          text: 'Wöchentlich',
+          class: 'btn-outline-info',
+        },
+      ]"
+    />
+    <openwb-base-text-input
+      v-if="plan.frequency.selected == 'once'"
+      v-model="plan.frequency.once"
+      title="Datum"
+      subtype="date"
+    />
+    <div v-if="plan.frequency.selected == 'weekly'">
+      <openwb-base-button-group-input
+        v-for="(day, dayIndex) in weekdays"
+        :key="dayIndex"
+        v-model="plan.frequency.weekly[dayIndex]"
+        :title="day"
+        :buttons="[
+          {
+            buttonValue: false,
+            text: 'Aus',
+            class: 'btn-outline-danger',
+          },
+          {
+            buttonValue: true,
+            text: 'An',
+            class: 'btn-outline-success',
+          },
+        ]"
+      />
+    </div>
+    <hr />
+    <openwb-base-range-input
+      v-model="plan.current"
+      :title="`Ladestrom${dcChargingEnabled ? ' (AC)' : ''}`"
+      :min="6"
+      :max="32"
+      :step="1"
+      unit="A"
+    >
+      <template #help>
+        Mit dieser Stromstärke wird der Zeitpunkt berechnet, wann die Ladung mit Netzbezug gestartet werden muss. Wird
+        der Ziel-SoC nicht zum angegebenen Termin erreicht, weil z.B. das Auto erst später angesteckt wurde, wird auch
+        mit einer höheren Stromstärke geladen. Um etwas Puffer zu haben, empfiehlt es sich, etwas weniger als die
+        Maximalstromstärke des Fahrzeugs zu wählen.
+      </template>
+    </openwb-base-range-input>
+    <openwb-base-number-input
+      v-if="dcChargingEnabled === true"
+      title="Ladeleistung (DC)"
+      unit="kW"
+      :min="0"
+      :model-value="ac_current2dc_power(plan.dc_current)"
+      @update:model-value="plan.dc_current = dc_power2ac_current($event)"
+    />
+    <openwb-base-button-group-input
+      v-model="plan.phases_to_use"
+      title="Anzahl Phasen Zielladen"
+      :buttons="[
+        { buttonValue: 1, text: '1' },
+        { buttonValue: 3, text: 'Maximum' },
+        { buttonValue: 0, text: 'Automatik' },
+      ]"
+    >
+      <template #help>
+        Hier kann eingestellt werden, ob Ladevorgänge im Modus "Zielladen" mit nur einer Phase oder dem möglichen
+        Maximum in Abhängigkeit der "Ladepunkt"- und "Fahrzeug"-Einstellungen durchgeführt werden. Im Modus "Automatik"
+        entscheidet die Regelung, welche Einstellung genutzt wird, um das Ziel zu erreichen. Voraussetzung ist die
+        verbaute Umschaltmöglichkeit zwischen 1- und 3-phasig (sog. 1p3p).
+      </template>
+    </openwb-base-button-group-input>
+    <openwb-base-button-group-input
+      v-model="plan.phases_to_use_pv"
+      title="Anzahl Phasen bei PV-Überschuss"
+      :buttons="[
+        { buttonValue: 1, text: '1' },
+        { buttonValue: 3, text: 'Maximum' },
+        { buttonValue: 0, text: 'Automatik' },
+      ]"
+    >
+      <template #help>
+        Hier kann eingestellt werden, ob Ladevorgänge im Modus "Zielladen" bei Laden mit PV-Überschuss mit nur einer
+        Phase oder dem möglichen Maximum in Abhängigkeit der "Ladepunkt"- und "Fahrzeug"-Einstellungen durchgeführt
+        werden. Im Modus "Automatik" entscheidet die Regelung, welche Einstellung genutzt wird, um das Ziel zu
+        erreichen. Voraussetzung ist die verbaute Umschaltmöglichkeit zwischen 1- und 3-phasig (sog. 1p3p).
+      </template>
+    </openwb-base-button-group-input>
+    <hr />
     <openwb-base-button-group-input
       v-model="plan.limit.selected"
       title="Ziel"
@@ -151,54 +255,6 @@
     </openwb-base-number-input>
     <hr />
     <openwb-base-button-group-input
-      v-model="plan.frequency.selected"
-      title="Wiederholungen"
-      :buttons="[
-        {
-          buttonValue: 'once',
-          text: 'Einmalig',
-          class: 'btn-outline-info',
-        },
-        {
-          buttonValue: 'daily',
-          text: 'Täglich',
-          class: 'btn-outline-info',
-        },
-        {
-          buttonValue: 'weekly',
-          text: 'Wöchentlich',
-          class: 'btn-outline-info',
-        },
-      ]"
-    />
-    <openwb-base-text-input
-      v-if="plan.frequency.selected == 'once'"
-      v-model="plan.frequency.once"
-      title="Datum"
-      subtype="date"
-    />
-    <div v-if="plan.frequency.selected == 'weekly'">
-      <openwb-base-button-group-input
-        v-for="(day, dayIndex) in weekdays"
-        :key="dayIndex"
-        v-model="plan.frequency.weekly[dayIndex]"
-        :title="day"
-        :buttons="[
-          {
-            buttonValue: false,
-            text: 'Aus',
-            class: 'btn-outline-danger',
-          },
-          {
-            buttonValue: true,
-            text: 'An',
-            class: 'btn-outline-success',
-          },
-        ]"
-      />
-    </div>
-    <hr />
-    <openwb-base-button-group-input
       v-model="plan.et_active"
       title="Strompreisbasiert Laden"
       :buttons="[
@@ -224,61 +280,6 @@
     >
       Bitte in den übergreifenden Ladeeinstellungen einen Strompreis-Anbieter konfigurieren.
     </openwb-base-alert>
-    <openwb-base-button-group-input
-      v-model="plan.phases_to_use"
-      title="Anzahl Phasen Zielladen"
-      :buttons="[
-        { buttonValue: 1, text: '1' },
-        { buttonValue: 3, text: 'Maximum' },
-        { buttonValue: 0, text: 'Automatik' },
-      ]"
-    >
-      <template #help>
-        Hier kann eingestellt werden, ob Ladevorgänge im Modus "Zielladen" mit nur einer Phase oder dem möglichen
-        Maximum in Abhängigkeit der "Ladepunkt"- und "Fahrzeug"-Einstellungen durchgeführt werden. Im Modus "Automatik"
-        entscheidet die Regelung, welche Einstellung genutzt wird, um das Ziel zu erreichen. Voraussetzung ist die
-        verbaute Umschaltmöglichkeit zwischen 1- und 3-phasig (sog. 1p3p).
-      </template>
-    </openwb-base-button-group-input>
-    <openwb-base-button-group-input
-      v-model="plan.phases_to_use_pv"
-      title="Anzahl Phasen bei PV-Überschuss"
-      :buttons="[
-        { buttonValue: 1, text: '1' },
-        { buttonValue: 3, text: 'Maximum' },
-        { buttonValue: 0, text: 'Automatik' },
-      ]"
-    >
-      <template #help>
-        Hier kann eingestellt werden, ob Ladevorgänge im Modus "Zielladen" bei Laden mit PV-Überschuss mit nur einer
-        Phase oder dem möglichen Maximum in Abhängigkeit der "Ladepunkt"- und "Fahrzeug"-Einstellungen durchgeführt
-        werden. Im Modus "Automatik" entscheidet die Regelung, welche Einstellung genutzt wird, um das Ziel zu
-        erreichen. Voraussetzung ist die verbaute Umschaltmöglichkeit zwischen 1- und 3-phasig (sog. 1p3p).
-      </template>
-    </openwb-base-button-group-input>
-    <openwb-base-range-input
-      v-model="plan.current"
-      :title="`Ladestrom${dcChargingEnabled ? ' (AC)' : ''}`"
-      :min="6"
-      :max="32"
-      :step="1"
-      unit="A"
-    >
-      <template #help>
-        Mit dieser Stromstärke wird der Zeitpunkt berechnet, wann die Ladung mit Netzbezug gestartet werden muss. Wird
-        der Ziel-SoC nicht zum angegebenen Termin erreicht, weil z.B. das Auto erst später angesteckt wurde, wird auch
-        mit einer höheren Stromstärke geladen. Um etwas Puffer zu haben, empfiehlt es sich, etwas weniger als die
-        Maximalstromstärke des Fahrzeugs zu wählen.
-      </template>
-    </openwb-base-range-input>
-    <openwb-base-number-input
-      v-if="dcChargingEnabled === true"
-      title="Ladeleistung (DC)"
-      unit="kW"
-      :min="0"
-      :model-value="ac_current2dc_power(plan.dc_current)"
-      @update:model-value="plan.dc_current = dc_power2ac_current($event)"
-    />
     <div v-if="plan.limit.selected == 'soc'">
       <hr />
       <openwb-base-button-group-input
@@ -316,17 +317,6 @@
         eingestellte Ladeleistung verwendet. Unterstützen das Fahrzeug und/oder der Ladepunkt die Norm nicht, wird der
         Ladestrom und die vorgegebene Phasenzahl angewendet.
       </openwb-base-alert>
-      <openwb-base-number-input
-        v-if="plan.bidi_charging_enabled === true"
-        title="Ladeleistung"
-        :min="1"
-        :max="22"
-        :step="0.5"
-        unit="kW"
-        :model-value="plan.bidi_power / 1000"
-        @update:model-value="updateState(templateKey, $event * 1000, 'plan.bidi_power')"
-      >
-      </openwb-base-number-input>
     </div>
   </openwb-base-card>
 </template>

--- a/src/components/vehicles/ChargeTemplateTimeChargingPlan.vue
+++ b/src/components/vehicles/ChargeTemplateTimeChargingPlan.vue
@@ -83,66 +83,6 @@
         },
       ]"
     />
-    <openwb-base-range-input
-      v-model="plan.current"
-      :title="`Ladestrom${dcChargingEnabled ? ' (AC)' : ''}`"
-      :min="6"
-      :max="32"
-      :step="1"
-      unit="A"
-    />
-    <openwb-base-number-input
-      v-if="dcChargingEnabled === true"
-      title="Ladeleistung (DC)"
-      unit="kW"
-      :min="0"
-      :model-value="ac_current2dc_power(plan.dc_current)"
-      @update:model-value="plan.dc_current = dc_power2ac_current($event)"
-    />
-    <openwb-base-button-group-input
-      v-model="plan.limit.selected"
-      title="Begrenzung"
-      :buttons="[
-        { buttonValue: 'none', text: 'Aus' },
-        {
-          buttonValue: 'soc',
-          text: 'Fahrzeug-SoC',
-        },
-        {
-          buttonValue: 'amount',
-          text: 'Energie',
-        },
-      ]"
-    >
-      <template #help> Bestimmt die Art der Grenze für den Ladevorgang. </template>
-    </openwb-base-button-group-input>
-    <openwb-base-range-input
-      v-model="plan.limit.soc"
-      title="Ziel-SoC für das Fahrzeug"
-      :min="5"
-      :max="100"
-      :step="5"
-      unit="%"
-    >
-      <template #help>
-        Ladestand des Akku (State of Charge, SoC), bis zu welchem maximal geladen werden soll.
-      </template>
-    </openwb-base-range-input>
-    <openwb-base-number-input
-      title="Ziel-Energie"
-      unit="kWh"
-      :min="1"
-      :step="0.5"
-      :model-value="plan.limit.amount / 1000"
-      @update:model-value="plan.limit.amount = $event * 1000"
-    >
-      <template #help>
-        Maximal zu ladende Energie innerhalb des Zeitfensters. Eignet sich immer dann wenn kein SoC zur Verfügung steht.
-        Die geladene Energiemenge wird beim Wechsel des Lademodus, Wechsel des Plans oder nach dem Anstecken, wenn
-        Zeitladen schon aktiv ist, neu gezählt.
-      </template>
-    </openwb-base-number-input>
-    <hr />
     <openwb-base-text-input
       v-model="plan.time[0]"
       title="Zeitpunkt des Ladebeginns"
@@ -208,6 +148,22 @@
       />
     </div>
     <hr />
+    <openwb-base-range-input
+      v-model="plan.current"
+      :title="`Ladestrom${dcChargingEnabled ? ' (AC)' : ''}`"
+      :min="6"
+      :max="32"
+      :step="1"
+      unit="A"
+    />
+    <openwb-base-number-input
+      v-if="dcChargingEnabled === true"
+      title="Ladeleistung (DC)"
+      unit="kW"
+      :min="0"
+      :model-value="ac_current2dc_power(plan.dc_current)"
+      @update:model-value="plan.dc_current = dc_power2ac_current($event)"
+    />
     <openwb-base-button-group-input
       v-model="plan.phases_to_use"
       title="Anzahl Phasen"
@@ -222,6 +178,50 @@
         Umschaltmöglichkeit zwischen 1- und 3-phasig (sog. 1p3p).
       </template>
     </openwb-base-button-group-input>
+    <hr />
+    <openwb-base-button-group-input
+      v-model="plan.limit.selected"
+      title="Begrenzung"
+      :buttons="[
+        { buttonValue: 'none', text: 'Keine' },
+        {
+          buttonValue: 'soc',
+          text: 'Fahrzeug-SoC',
+        },
+        {
+          buttonValue: 'amount',
+          text: 'Energie',
+        },
+      ]"
+    >
+      <template #help> Bestimmt die Art der Grenze für den Ladevorgang. </template>
+    </openwb-base-button-group-input>
+    <openwb-base-range-input
+      v-model="plan.limit.soc"
+      title="Ziel-SoC für das Fahrzeug"
+      :min="5"
+      :max="100"
+      :step="5"
+      unit="%"
+    >
+      <template #help>
+        Ladestand des Akku (State of Charge, SoC), bis zu welchem maximal geladen werden soll.
+      </template>
+    </openwb-base-range-input>
+    <openwb-base-number-input
+      title="Ziel-Energie"
+      unit="kWh"
+      :min="1"
+      :step="0.5"
+      :model-value="plan.limit.amount / 1000"
+      @update:model-value="plan.limit.amount = $event * 1000"
+    >
+      <template #help>
+        Maximal zu ladende Energie innerhalb des Zeitfensters. Eignet sich immer dann wenn kein SoC zur Verfügung steht.
+        Die geladene Energiemenge wird beim Wechsel des Lademodus, Wechsel des Plans oder nach dem Anstecken, wenn
+        Zeitladen schon aktiv ist, neu gezählt.
+      </template>
+    </openwb-base-number-input>
   </openwb-base-card>
 </template>
 

--- a/src/components/vehicles/ChargeTemplateTimeChargingPlan.vue
+++ b/src/components/vehicles/ChargeTemplateTimeChargingPlan.vue
@@ -198,7 +198,7 @@
     </openwb-base-button-group-input>
     <openwb-base-range-input
       v-model="plan.limit.soc"
-      title="Ziel-SoC für das Fahrzeug"
+      title="SoC-Limit für das Fahrzeug"
       :min="5"
       :max="100"
       :step="5"
@@ -209,7 +209,7 @@
       </template>
     </openwb-base-range-input>
     <openwb-base-number-input
-      title="Ziel-Energie"
+      title="Energie-Limit"
       unit="kWh"
       :min="1"
       :step="0.5"

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -850,7 +850,7 @@
                 :buttons="[
                   {
                     buttonValue: 'none',
-                    text: 'Aus',
+                    text: 'Keine',
                   },
                   {
                     buttonValue: 'soc',
@@ -976,7 +976,7 @@
                 :buttons="[
                   {
                     buttonValue: 'none',
-                    text: 'Aus',
+                    text: 'Keine',
                   },
                   {
                     buttonValue: 'soc',
@@ -1232,7 +1232,7 @@
                 :buttons="[
                   {
                     buttonValue: 'none',
-                    text: 'Aus',
+                    text: 'Keine',
                   },
                   {
                     buttonValue: 'soc',


### PR DESCRIPTION
- Ladepläne passen die Eingaben an das Koala-Theme an
- Begrenzung "Au" >> "Keine" wie in Koala Theme
- 
<img width="1024" height="945" alt="Bildschirmfoto 2025-12-10 um 14 58 33" src="https://github.com/user-attachments/assets/5d94d389-505a-486a-bf4a-f8ff444b1b7a" />

<img width="1047" height="682" alt="Bildschirmfoto 2025-12-10 um 15 22 33" src="https://github.com/user-attachments/assets/37feae8b-5d6e-4fce-ad6d-689de77ab8b9" />

<img width="1056" height="360" alt="Bildschirmfoto 2025-12-10 um 15 22 52" src="https://github.com/user-attachments/assets/64cce2b0-d269-4ae6-a254-ea000346466f" />
