### PR TITLE
Button group allow named slots to be passed to child component "OpenwbBaseButtonRow.vue"

### DIFF
--- a/src/components/OpenwbBaseButtonGroupInput.vue
+++ b/src/components/OpenwbBaseButtonGroupInput.vue
@@ -24,7 +24,18 @@
           v-bind="$attrs"
           @update:model-value="value = $event"
           @button-click="$emit('button-click', $event)"
-        />
+        >
+          <!-- Forward all label slots -->
+          <template
+            v-for="btn in row"
+            #[`label-${btn.buttonValue}`]="slotProps"
+          >
+            <slot
+              :name="`label-${btn.buttonValue}`"
+              v-bind="slotProps"
+            />
+          </template>
+        </openwb-base-button-row>
       </div>
     </template>
   </openwb-base-setting-element>

--- a/src/components/OpenwbBaseButtonGroupInput.vue
+++ b/src/components/OpenwbBaseButtonGroupInput.vue
@@ -80,7 +80,6 @@ export default {
       if (this.containerWidth <= 200) return 1;
       if (this.containerWidth <= 360) return 2;
       if (this.containerWidth <= 550) return 3;
-      if (this.containerWidth <= 1024) return 4;
       return Infinity;
     },
     buttonRows() {


### PR DESCRIPTION
Parent Basis-komponent Button-Gruppe  "OpenwbBaseButtonGroupInput" erlaubt, benannte Slots an die Child-komponent ‚OpenwbBaseButtonRow.vue‘ zu übergeben.  (Labels, icons, usw)


<img width="2910" height="596" alt="image (2)" src="https://github.com/user-attachments/assets/dc7f1b7f-219c-4480-ba3f-3d30745d2997" />

<img width="948" height="480" alt="Bildschirmfoto 2025-12-19 um 11 19 41" src="https://github.com/user-attachments/assets/89b84b03-9997-4bb6-af1d-c35d0389ae81" />
