### PR TITLE
Add UI input for dummy_id_tag in OCPP settings

### DIFF
--- a/src/views/GeneralChargeConfig.vue
+++ b/src/views/GeneralChargeConfig.vue
@@ -213,6 +213,17 @@
               :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.version"
               @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'version')"
             />
+            <openwb-base-text-input
+              title="Standard ID-Tag"
+              :model-value="$store.state.mqtt['openWB/optional/ocpp/config']?.dummy_id_tag"
+              @update:model-value="updateState('openWB/optional/ocpp/config', $event, 'dummy_id_tag')"
+            >
+              <template #help>
+                Wenn hier ein ID-Tag eingetragen wird, wird dieser bei allen OCPP-Transaktionen verwendet,
+                unabhängig davon ob ein physischer RFID-Tag gescannt wurde oder nicht.
+                Leer lassen, um den tatsächlich gescannten ID-Tag zu verwenden.
+              </template>
+            </openwb-base-text-input>
           </div>
         </div>
       </openwb-base-card>


### PR DESCRIPTION
## Description

This feature adds the ability to configure a default/dummy RFID card ID in the OCPP settings. When configured, this ID-Tag will be used for all OCPP transactions (StartTransaction and StopTransaction) regardless of whether a physical RFID card was scanned.

## Use Case

This is useful when:
- You don't want to scan an RFID card for every charging session
- Your OCPP backend requires an ID-Tag but you don't have physical RFID cards
- You want to use a fixed ID-Tag for all transactions from this chargepoint

## Changes

**Backend (core):**
- Added dummy_id_tag field to Ocpp dataclass
- Modified chargepoint logic to use dummy_id_tag (if configured) as the first priority for both start_transaction and stop_transaction calls

**Frontend (openwb-ui-settings):**
- Added "Standard ID-Tag" input field in OCPP settings section
- Includes help text explaining the feature

## Behavior

| dummy_id_tag | Result |
|--------------|--------|
| Set | Always use this value for OCPP transactions |
| Empty | Fall back to scanned RFID tag or vehicle ID (existing behavior) |

## Configuration

The setting is available under: **Einstellungen → Allgemein → Laden → OCPP → Standard ID-Tag**