### PR TITLE
Status card "Variable Strompreise" not displayed if price data is empty - (Tariff configured) 

### DIFF
--- a/src/components/status/ElectricityPricingCard.vue
+++ b/src/components/status/ElectricityPricingCard.vue
@@ -265,19 +265,23 @@ export default {
           });
         }
         // repeat last dataset
-        const lastData = myData.slice(-1)[0];
-        // midnight as default
-        let nextTimestamp = this.endOfToday;
-        if (myData.length > 1) {
-          // same offset minus 1ms as the last one
-          const previousData = myData.slice(-2, -1)[0];
-          nextTimestamp = lastData.timestamp + lastData.timestamp - previousData.timestamp - 1;
+        if (myData.length > 0) {
+          const lastData = myData.slice(-1)[0];
+          // midnight as default
+          let nextTimestamp = this.endOfToday;
+          if (myData.length > 1) {
+            // same offset minus 1ms as the last one
+            const previousData = myData.slice(-2, -1)[0];
+            nextTimestamp = lastData.timestamp + lastData.timestamp - previousData.timestamp - 1;
+          }
+          myData.push({
+            timestamp: nextTimestamp,
+            price: lastData.price,
+          });
         }
-        myData.push({
-          timestamp: nextTimestamp,
-          price: lastData.price,
-        });
         dataObject.datasets[0].data = myData;
+      } else {
+        dataObject.datasets[0].hidden = true;
       }
 
       // Stromtarif-Preise


### PR DESCRIPTION
Bei bestimmten Konstellationen (z. B. Tibber-Accounts ohne aktive Subscription) liefert der Backend zwar das MQTT-Topic für dynamische Strompreise, jedoch keine Preisdaten (leeres Objekt).

Im Frontend wurde in diesem Fall in der ElectricityPricingCard beim Erzeugen der Chart-Daten davon ausgegangen, dass mindestens ein Preiswert vorhanden ist.
Dadurch wurde beim „Wiederholen des letzten Datenpunkts“ auf ein nicht existentes Element zugegriffen (lastData war undefined), was zu einem Fehler in einer computed property führte.

Dieser Fehler hat dazu geführt, dass Vue die Komponente nicht vollständig rendern konnte und die Status-Karte gar nicht angezeigt wurde, obwohl ein Provider konfiguriert war. >> Kein Fehlermeldung sichtbar.

Änderung:
Das Erzeugen der Chart-Daten wurde abgesichert.
	•	Der letzte Datenpunkt wird nur noch dann wiederholt, wenn mindestens ein Preiswert vorhanden ist.
	•	Leere Preisdaten werden als gültiger Zustand behandelt (leeres Dataset), sodass:
	•	die Status-Karte weiterhin angezeigt wird
	•	Backend-Fehlermeldungen (über fault_state) sichtbar bleiben

<img width="551" height="709" alt="Bildschirmfoto 2026-01-16 um 09 21 08" src="https://github.com/user-attachments/assets/229a66b0-68b1-4d74-9c43-b90a8e32044b" />
