### PR TITLE
Fix UI freeze when discarding changes caused by async MQTT state

### DIFF
--- a/src/components/devices/OpenwbConfigProxy.vue
+++ b/src/components/devices/OpenwbConfigProxy.vue
@@ -26,7 +26,7 @@ export default {
       console.debug(`loading component: ${this.device?.type} / ${this.component?.type}`);
       if (this.component !== undefined) {
         return defineAsyncComponent({
-          loader: () => import(`./${this.device.vendor}/${this.device.type}/${this.component.type}.vue`),
+          loader: () => import(`./${this.device?.vendor}/${this.device?.type}/${this.component?.type}.vue`),
           errorComponent: OpenwbComponentConfigFallback,
         });
       } else {

--- a/src/components/devices/OpenwbConfigProxy.vue
+++ b/src/components/devices/OpenwbConfigProxy.vue
@@ -3,9 +3,9 @@
     :is="getComponent()"
     :device="device"
     :component="component"
-    :configuration="component ? component.configuration : device.configuration"
-    :device-id="device.id"
-    :device-type="device.type"
+    :configuration="component ? component.configuration : device?.configuration"
+    :device-id="device?.id"
+    :device-type="device?.type"
     :component-id="component ? component.id : undefined"
     :component-type="component ? component.type : undefined"
     @update:configuration="updateConfiguration($event)"
@@ -26,7 +26,7 @@ export default {
   emits: ["update:configuration"],
   methods: {
     getComponent() {
-      console.debug(`loading component: ${this.device.type} / ${this.component?.type}`);
+      console.debug(`loading component: ${this.device?.type} / ${this.component?.type}`);
       if (this.component !== undefined) {
         return defineAsyncComponent({
           loader: () => import(`./${this.device.vendor}/${this.device.type}/${this.component.type}.vue`),
@@ -34,7 +34,7 @@ export default {
         });
       } else {
         return defineAsyncComponent({
-          loader: () => import(`./${this.device.vendor}/${this.device.type}/device.vue`),
+          loader: () => import(`./${this.device.vendor}/${this.device?.type}/device.vue`),
           errorComponent: OpenwbDeviceConfigFallback,
         });
       }

--- a/src/components/devices/OpenwbConfigProxy.vue
+++ b/src/components/devices/OpenwbConfigProxy.vue
@@ -3,9 +3,6 @@
     :is="getComponent()"
     :device="device"
     :component="component"
-    :configuration="component ? component.configuration : device?.configuration"
-    :device-id="device?.id"
-    :device-type="device?.type"
     :component-id="component ? component.id : undefined"
     :component-type="component ? component.type : undefined"
     @update:configuration="updateConfiguration($event)"
@@ -34,7 +31,7 @@ export default {
         });
       } else {
         return defineAsyncComponent({
-          loader: () => import(`./${this.device.vendor}/${this.device?.type}/device.vue`),
+          loader: () => import(`./${this.device?.vendor}/${this.device?.type}/device.vue`),
           errorComponent: OpenwbDeviceConfigFallback,
         });
       }

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -527,9 +527,8 @@ export default {
         let myObj = {};
         for (const [key, element] of Object.entries(chargePoints)) {
           if (
-            element &&
-            typeof element === "object" &&
-            (element.type === "internal_openwb" || this.$store.state.mqtt["openWB/general/extern"] === false)
+            (element && typeof element === "object" && element.type === "internal_openwb") ||
+            this.$store.state.mqtt["openWB/general/extern"] === false
           ) {
             myObj[key] = element;
           }

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -526,17 +526,22 @@ export default {
         let chargePoints = this.getWildcardTopics("openWB/chargepoint/+/config");
         let myObj = {};
         for (const [key, element] of Object.entries(chargePoints)) {
-          if (element.type === "internal_openwb" || this.$store.state.mqtt["openWB/general/extern"] === false) {
+          if (
+            element &&
+            typeof element === "object" &&
+            (element.type === "internal_openwb" || this.$store.state.mqtt["openWB/general/extern"] === false)
+          ) {
             myObj[key] = element;
           }
         }
         return myObj;
       },
     },
-    chargePointTemplates: {
-      get() {
-        return this.getWildcardTopics("openWB/chargepoint/template/+");
-      },
+    chargePointTemplates() {
+      const chargePointTemplates = this.getWildcardTopics("openWB/chargepoint/template/+");
+      return Object.fromEntries(
+        Object.entries(chargePointTemplates).filter(([, template]) => template && typeof template === "object"),
+      );
     },
     chargePointTemplateList: {
       get() {

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -47,7 +47,7 @@
         <openwb-base-card
           v-for="(installedChargePoint, installedChargePointKey) in installedChargePoints"
           :key="installedChargePointKey"
-          :title="installedChargePoint.name + ' (ID: ' + installedChargePoint.id + ')'"
+          :title="installedChargePoint?.name + ' (ID: ' + installedChargePoint?.id + ')'"
           :collapsible="true"
           :collapsed="true"
           subtype="primary"
@@ -65,7 +65,7 @@
           <openwb-base-text-input
             title="Bezeichnung"
             subtype="text"
-            :model-value="installedChargePoint.name"
+            :model-value="installedChargePoint?.name"
             @update:model-value="updateState(installedChargePointKey, $event, 'name')"
           />
           <openwb-base-text-input
@@ -77,7 +77,7 @@
           />
           <span
             v-if="
-              installedChargePoint.type !== 'internal_openwb' || $store.state.mqtt['openWB/general/extern'] === false
+              installedChargePoint?.type !== 'internal_openwb' || $store.state.mqtt['openWB/general/extern'] === false
             "
           >
             <openwb-base-select-input
@@ -90,7 +90,7 @@
           <openwb-base-text-input
             v-if="$store.state.mqtt['openWB/optional/ocpp/config']['active'] === true"
             title="OCPP-Chargebox ID"
-            :model-value="installedChargePoint.ocpp_chargebox_id"
+            :model-value="installedChargePoint?.ocpp_chargebox_id"
             @update:model-value="updateState(installedChargePointKey, $event, 'ocpp_chargebox_id')"
           >
             <template #help>
@@ -105,9 +105,9 @@
           />
           <div
             v-if="
-              (installedChargePoint.type !== 'internal_openwb' ||
+              (installedChargePoint?.type !== 'internal_openwb' ||
                 $store.state.mqtt['openWB/general/extern'] === false) &&
-              installedChargePoint.charging_type !== 'DC'
+              installedChargePoint?.charging_type !== 'DC'
             "
           >
             <hr />
@@ -118,7 +118,7 @@
                 { buttonValue: false, text: 'Nein' },
                 { buttonValue: true, text: 'Ja' },
               ]"
-              :model-value="installedChargePoint.auto_phase_switch_hw"
+              :model-value="installedChargePoint?.auto_phase_switch_hw"
               @update:model-value="updateState(installedChargePointKey, $event, 'auto_phase_switch_hw')"
             />
             <openwb-base-button-group-input
@@ -127,7 +127,7 @@
                 { buttonValue: false, text: 'Nein' },
                 { buttonValue: true, text: 'Ja' },
               ]"
-              :model-value="installedChargePoint.control_pilot_interruption_hw"
+              :model-value="installedChargePoint?.control_pilot_interruption_hw"
               @update:model-value="updateState(installedChargePointKey, $event, 'control_pilot_interruption_hw')"
             >
               <template #help>
@@ -146,7 +146,7 @@
                 { buttonValue: 2, text: '2' },
                 { buttonValue: 3, text: '3' },
               ]"
-              :model-value="installedChargePoint.connected_phases"
+              :model-value="installedChargePoint?.connected_phases"
               @update:model-value="updateState(installedChargePointKey, $event, 'connected_phases')"
             />
             <openwb-base-button-group-input
@@ -156,7 +156,7 @@
                 { buttonValue: 2, text: 'EVU L2' },
                 { buttonValue: 3, text: 'EVU L3' },
               ]"
-              :model-value="installedChargePoint.phase_1"
+              :model-value="installedChargePoint?.phase_1"
               @update:model-value="updateState(installedChargePointKey, $event, 'phase_1')"
             >
               <template #help>

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -62,10 +62,10 @@
               <div v-else>
                 <openwb-base-avatar
                   v-for="installedComponent in getMyInstalledComponents(installedDevice?.id)"
-                  :key="installedComponent.id"
-                  :class="'ml-1 bg-' + getComponentTypeClass(installedComponent.type)"
+                  :key="installedComponent?.id"
+                  :class="'ml-1 bg-' + getComponentTypeClass(installedComponent?.type)"
                 >
-                  <font-awesome-icon :icon="getComponentTypeIcon(installedComponent.type)" />
+                  <font-awesome-icon :icon="getComponentTypeIcon(installedComponent?.type)" />
                 </openwb-base-avatar>
               </div>
             </template>
@@ -89,7 +89,7 @@
               Es wurden noch keine Komponenten zu diesem Gerät angelegt.
             </openwb-base-alert>
             <openwb-base-card
-              v-for="(installedComponent, installedComponentKey) in getMyInstalledComponents(installedDevice.id)"
+              v-for="(installedComponent, installedComponentKey) in getMyInstalledComponents(installedDevice?.id)"
               :key="installedComponent.id"
               :collapsible="true"
               :collapsed="true"
@@ -147,7 +147,7 @@
             </openwb-base-card>
             <hr />
             <openwb-base-select-input
-              v-if="getComponentList(installedDevice.vendor, installedDevice.type).length"
+              v-if="getComponentList(installedDevice?.vendor, installedDevice?.type)?.length"
               title="Verfügbare Komponenten"
               not-selected="Bitte auswählen"
               :options="getComponentList(installedDevice.vendor, installedDevice.type)"
@@ -282,15 +282,17 @@ export default {
     };
   },
   computed: {
-    installedDevices: {
-      get() {
-        return this.getWildcardTopics("openWB/system/device/+/config");
-      },
+    installedDevices() {
+      const installedDevices = this.getWildcardTopics("openWB/system/device/+/config");
+      return Object.fromEntries(
+        Object.entries(installedDevices).filter(([, template]) => template && typeof template === "object"),
+      );
     },
-    installedComponents: {
-      get() {
-        return this.getWildcardTopics("openWB/system/device/+/component/+/config");
-      },
+    installedComponents() {
+      const installedComponents = this.getWildcardTopics("openWB/system/device/+/component/+/config");
+      return Object.fromEntries(
+        Object.entries(installedComponents).filter(([, template]) => template && typeof template === "object"),
+      );
     },
     vendorList: {
       get() {

--- a/src/views/HardwareInstallation.vue
+++ b/src/views/HardwareInstallation.vue
@@ -302,7 +302,7 @@ export default {
         }
         return Object.entries(devicesComponents)
           .map(([groupKey, group]) => {
-            // Fallback für group.vendors
+            // Fallback for group.vendors
             const vendors = group?.vendors || {};
             return {
               label: group?.group_name || "",
@@ -314,7 +314,7 @@ export default {
                 .sort((a, b) => a.text.localeCompare(b.text)),
             };
           })
-          .sort((a, b) => -a.label.localeCompare(b.label));
+          .sort((a, b) => -a.label.localeCompare(b.label)); // reverse order to have "openWB" at the top
       },
     },
     deviceList: {

--- a/src/views/IoConfig.vue
+++ b/src/views/IoConfig.vue
@@ -199,10 +199,11 @@ export default {
         return this.$store.state.mqtt["openWB/system/configurable/io_devices"];
       },
     },
-    installedIoDevices: {
-      get() {
-        return this.getWildcardTopics("openWB/system/io/+/config");
-      },
+    installedIoDevices() {
+      const installedIoDevices = this.getWildcardTopics("openWB/system/io/+/config");
+      return Object.fromEntries(
+        Object.entries(installedIoDevices).filter(([, template]) => template && typeof template === "object"),
+      );
     },
     ioActionList: {
       get() {

--- a/src/views/MqttBridgeConfig.vue
+++ b/src/views/MqttBridgeConfig.vue
@@ -47,7 +47,7 @@
           :name="'mqttBridgeConfigurationForm' + getMqttBridgeIndex(mqttBridgeKey)"
         >
           <openwb-base-card
-            :title="mqttBridge.name"
+            :title="mqttBridge?.name"
             :collapsible="true"
             :collapsed="true"
             subtype="primary"
@@ -65,7 +65,7 @@
               subtype="text"
               required
               pattern="[A-Za-z0-9]+"
-              :model-value="mqttBridge.name"
+              :model-value="mqttBridge?.name"
               @update:model-value="updateState(mqttBridgeKey, $event, 'name')"
             >
               <template #help> Die Bezeichnung darf nur aus Buchstaben ohne Umlaute und Zahlen bestehen. </template>
@@ -84,7 +84,7 @@
                   class: 'btn-outline-success',
                 },
               ]"
-              :model-value="mqttBridge.active"
+              :model-value="mqttBridge?.active"
               @update:model-value="updateState(mqttBridgeKey, $event, 'active')"
             />
             <hr />
@@ -93,7 +93,7 @@
               title="Entfernter Server"
               subtype="host"
               required
-              :model-value="mqttBridge.remote.host"
+              :model-value="mqttBridge?.remote?.host"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.host')"
             />
             <openwb-base-number-input
@@ -101,7 +101,7 @@
               required
               :min="1"
               :max="65535"
-              :model-value="mqttBridge.remote.port"
+              :model-value="mqttBridge?.remote?.port"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.port')"
             />
             <openwb-base-text-input
@@ -109,21 +109,21 @@
               subtype="user"
               required
               pattern="[a-zA-Z0-9_\-+.]+"
-              :model-value="mqttBridge.remote.username"
+              :model-value="mqttBridge?.remote?.username"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.username')"
             />
             <openwb-base-text-input
               title="Passwort"
               subtype="password"
               required
-              :model-value="mqttBridge.remote.password"
+              :model-value="mqttBridge?.remote?.password"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.password')"
             />
             <openwb-base-text-input
               title="Präfix"
               subtype="text"
               pattern="[A-Za-z0-9_\-]+(\/[A-Za-z0-9_\-]+)?\/"
-              :model-value="mqttBridge.remote.prefix"
+              :model-value="mqttBridge?.remote?.prefix"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.prefix')"
             >
               <template #help>
@@ -137,7 +137,7 @@
               subtype="text"
               required
               pattern="[A-Za-z0-9_\-]+"
-              :model-value="mqttBridge.remote.client_id"
+              :model-value="mqttBridge?.remote?.client_id"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.client_id')"
             >
               <template #help>
@@ -157,7 +157,7 @@
                   text: 'v3.1.1',
                 },
               ]"
-              :model-value="mqttBridge.remote.protocol"
+              :model-value="mqttBridge?.remote?.protocol"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.protocol')"
             />
             <openwb-base-button-group-input
@@ -183,7 +183,7 @@
                   text: 'v1.2',
                 },
               ]"
-              :model-value="mqttBridge.remote.tls_version"
+              :model-value="mqttBridge?.remote?.tls_version"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.tls_version')"
             >
               <template #help>
@@ -206,7 +206,7 @@
                   class: 'btn-outline-success',
                 },
               ]"
-              :model-value="mqttBridge.remote.try_private"
+              :model-value="mqttBridge?.remote?.try_private"
               @update:model-value="updateState(mqttBridgeKey, $event, 'remote.try_private')"
             >
               <template #help>
@@ -232,7 +232,7 @@
                   class: 'btn-outline-success',
                 },
               ]"
-              :model-value="mqttBridge.data_transfer.status"
+              :model-value="mqttBridge?.data_transfer?.status"
               @update:model-value="updateState(mqttBridgeKey, $event, 'data_transfer.status')"
             >
               <template #help>
@@ -254,7 +254,7 @@
                   class: 'btn-outline-success',
                 },
               ]"
-              :model-value="mqttBridge.data_transfer.graph"
+              :model-value="mqttBridge?.data_transfer?.graph"
               @update:model-value="updateState(mqttBridgeKey, $event, 'data_transfer.graph')"
             >
               <template #help>
@@ -279,7 +279,7 @@
                   class: 'btn-outline-success',
                 },
               ]"
-              :model-value="mqttBridge.data_transfer.configuration"
+              :model-value="mqttBridge?.data_transfer?.configuration"
               @update:model-value="updateState(mqttBridgeKey, $event, 'data_transfer.configuration')"
             >
               <template #help>
@@ -331,13 +331,17 @@ export default {
   computed: {
     configuredMqttBridges: {
       get() {
-        let bridges = this.getWildcardTopics("openWB/system/mqtt/bridge/+");
-        for (const [key, value] of Object.entries(bridges)) {
-          if (value.remote.is_openwb_cloud) {
-            delete bridges[key];
+        const bridges = this.getWildcardTopics("openWB/system/mqtt/bridge/+");
+        if (!bridges || typeof bridges !== "object") {
+          return {};
+        }
+        const filtered = { ...bridges };
+        for (const [key, value] of Object.entries(filtered)) {
+          if (value?.remote?.is_openwb_cloud) {
+            delete filtered[key];
           }
         }
-        return bridges;
+        return filtered;
       },
     },
   },

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -1487,6 +1487,8 @@ export default {
     evTemplates() {
       const evTemplates = this.getWildcardTopics("openWB/vehicle/template/ev_template/+");
       return Object.fromEntries(
+        // Filter out temporarily undefined entries caused by async MQTT (unsubscribe/resubscribe),
+        // (on button push, discard changes) so templates never try to render incomplete data.
         Object.entries(evTemplates).filter(([, template]) => template && typeof template === "object"),
       );
     },
@@ -1504,6 +1506,8 @@ export default {
     chargeTemplates() {
       const chargeTemplates = this.getWildcardTopics("openWB/vehicle/template/charge_template/+");
       return Object.fromEntries(
+        // Filter out temporarily undefined entries caused by async MQTT (unsubscribe/resubscribe),
+        // (on button push, discard changes) so templates never try to render incomplete data.
         Object.entries(chargeTemplates).filter(([, template]) => template && typeof template === "object"),
       );
     },

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -96,7 +96,7 @@
             <openwb-base-text-input
               v-if="vehicleId !== 0"
               title="Fahrzeughersteller "
-              :model-value="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/info'].manufacturer"
+              :model-value="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/info']?.manufacturer"
               @update:model-value="updateState('openWB/vehicle/' + vehicleId + '/info', $event, 'manufacturer')"
             >
               <template #help> Optional: zusätzliche Information für den Systembericht. </template>
@@ -104,7 +104,7 @@
             <openwb-base-text-input
               v-if="vehicleId !== 0"
               title="Fahrzeugmodell"
-              :model-value="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/info'].model"
+              :model-value="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/info']?.model"
               @update:model-value="updateState('openWB/vehicle/' + vehicleId + '/info', $event, 'model')"
             >
               <template #help>
@@ -132,7 +132,7 @@
             <hr />
             <div v-if="!installAssistantActive">
               <openwb-base-heading> Fahrzeugzuordnung per ID-Tags </openwb-base-heading>
-              <div v-if="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/tag_id'].length > 0">
+              <div v-if="($store.state.mqtt['openWB/vehicle/' + vehicleId + '/tag_id']?.length ?? 0) > 0">
                 <openwb-base-alert subtype="info">
                   Einstellungen zur Fahrzeugzuordnung finden sich unter
                   <router-link to="/IdentificationConfig"> Einstellungen - Identifikation </router-link>.
@@ -169,7 +169,7 @@
               class="mb-2"
               title="SoC-Modul des Fahrzeugs"
               :options="socModuleList"
-              :model-value="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/soc_module/config'].type"
+              :model-value="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/soc_module/config']?.type"
               @update:model-value="updateSelectedSocModule(vehicleId, $event)"
             >
               <template #help>
@@ -189,7 +189,7 @@
                 infolge von zeitlicher Verzögerungen kommen. Hilfestellung erfolgt primär im openWB-Forum.
               </template>
             </openwb-base-select-input>
-            <div v-if="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/soc_module/config'].type">
+            <div v-if="$store.state.mqtt['openWB/vehicle/' + vehicleId + '/soc_module/config']?.type">
               <openwb-base-button-group-input
                 title="SoC direkt aus Fahrzeug auslesen"
                 :buttons="[
@@ -205,7 +205,7 @@
                   },
                 ]"
                 :model-value="
-                  $store.state.mqtt['openWB/vehicle/' + vehicleId + '/soc_module/general_config'].use_soc_from_cp
+                  $store.state.mqtt['openWB/vehicle/' + vehicleId + '/soc_module/general_config']?.use_soc_from_cp
                 "
                 @update:model-value="
                   updateState('openWB/vehicle/' + vehicleId + '/soc_module/general_config', $event, 'use_soc_from_cp')
@@ -233,7 +233,7 @@
                 required
                 :model-value="
                   $store.state.mqtt['openWB/vehicle/' + vehicleId + '/soc_module/general_config']
-                    .request_interval_charging / 60
+                    ?.request_interval_charging / 60
                 "
                 @update:model-value="
                   updateState(

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -1502,9 +1502,9 @@ export default {
       },
     },
     chargeTemplates() {
-      const chargeTemplate = this.getWildcardTopics("openWB/vehicle/template/charge_template/+");
+      const chargeTemplates = this.getWildcardTopics("openWB/vehicle/template/charge_template/+");
       return Object.fromEntries(
-        Object.entries(chargeTemplate).filter(([, template]) => template && typeof template === "object"),
+        Object.entries(chargeTemplates).filter(([, template]) => template && typeof template === "object"),
       );
     },
     chargeTemplateList: {

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -667,7 +667,7 @@
         </div>
         <div v-else>
           <openwb-base-card
-            v-for="(template, templateKey) in chargeTemplates"
+            v-for="{ key: templateKey, template } in chargeTemplates"
             :key="templateKey"
             :title="template.name ? template.name : templateKey"
             :collapsible="true"
@@ -1500,10 +1500,13 @@ export default {
         return myList;
       },
     },
-    chargeTemplates: {
-      get() {
-        return this.getWildcardTopics("openWB/vehicle/template/charge_template/+");
-      },
+    chargeTemplates() {
+      return (
+        Object.entries(this.getWildcardTopics("openWB/vehicle/template/charge_template/+"))
+          // Filter out invalid templates and prepare the data for the template as an array
+          .filter(([, template]) => template && typeof template === "object")
+          .map(([key, template]) => ({ key, template }))
+      );
     },
     chargeTemplateList: {
       get() {

--- a/src/views/VehicleConfig.vue
+++ b/src/views/VehicleConfig.vue
@@ -667,7 +667,7 @@
         </div>
         <div v-else>
           <openwb-base-card
-            v-for="{ key: templateKey, template } in chargeTemplates"
+            v-for="(template, templateKey) in chargeTemplates"
             :key="templateKey"
             :title="template.name ? template.name : templateKey"
             :collapsible="true"
@@ -1484,10 +1484,11 @@ export default {
         return this.getWildcardIndexList("openWB/vehicle/+/name");
       },
     },
-    evTemplates: {
-      get() {
-        return this.getWildcardTopics("openWB/vehicle/template/ev_template/+");
-      },
+    evTemplates() {
+      const evTemplates = this.getWildcardTopics("openWB/vehicle/template/ev_template/+");
+      return Object.fromEntries(
+        Object.entries(evTemplates).filter(([, template]) => template && typeof template === "object"),
+      );
     },
     evTemplateList: {
       get() {
@@ -1501,11 +1502,9 @@ export default {
       },
     },
     chargeTemplates() {
-      return (
-        Object.entries(this.getWildcardTopics("openWB/vehicle/template/charge_template/+"))
-          // Filter out invalid templates and prepare the data for the template as an array
-          .filter(([, template]) => template && typeof template === "object")
-          .map(([key, template]) => ({ key, template }))
+      const chargeTemplate = this.getWildcardTopics("openWB/vehicle/template/charge_template/+");
+      return Object.fromEntries(
+        Object.entries(chargeTemplate).filter(([, template]) => template && typeof template === "object"),
       );
     },
     chargeTemplateList: {


### PR DESCRIPTION
Bei Fahrzeug Konfiguration UI Render Problem bei Bestätigung von "Änderungen verwerfen" Dialog. 

Durch das Zurücksetzen werden MQTT-Topics kurzzeitig entfernt und anschließend erneut abonniert. In dieser Phase waren einzelne Store-Einträge undefined, während das Template weiterhin davon ausging, dass vollständige Objekte vorhanden sind.
Dadurch kam es zu Zugriffen auf nicht existierende Properties (z. B. .length, .manufacturer, .name), was zu Laufzeitfehlern führte. In der Folge blieben Bestätigungs-Dialoge geöffnet und die Seite war nicht mehr bedienbar.

Lösung:
•	Optional Chaining im Template
Alle Zugriffe auf verschachtelte, asynchron geladene Store-Daten verwenden nun optional chaining (?.). Dadurch werden Zugriffe auf temporär nicht verfügbare Objekte sicher abgefangen.

•	Gefilterte Computed Properties für Templates
Die Computed Properties evTemplates und chargeTemplates filtern ungültige bzw. nicht geladene Einträge und geben ausschließlich gültige Objekte zurück.

<img width="390" height="255" alt="Bildschirmfoto 2026-01-26 um 18 36 22" src="https://github.com/user-attachments/assets/15be7e7f-aaff-433b-a740-afc1326a73e0" />
