### PR TITLE
Add system version mixin

### DIFF
--- a/src/components/mixins/ComponentState.vue
+++ b/src/components/mixins/ComponentState.vue
@@ -19,8 +19,6 @@ export default {
     },
   },
   mounted() {
-    this.$root.doSubscribe(["openWB/system/version"]);
-
     if (this.mqttTopicsToSubscribe.length > 0) {
       this.$root.doSubscribe(this.mqttTopicsToSubscribe);
     }

--- a/src/components/mixins/ComponentState.vue
+++ b/src/components/mixins/ComponentState.vue
@@ -17,11 +17,6 @@ export default {
     mqttTopicsToPublish() {
       return this.mqttTopics.filter((topic) => topic.writeable).map((topic) => topic.topic);
     },
-    systemVersion() {
-      const version = this.$store.state.mqtt["openWB/system/version"];
-      const match = version?.match(/^\d+\.\d+\.\d+/);
-      return match ? match[0] : "2.1.8";
-    },
   },
   mounted() {
     this.$root.doSubscribe(["openWB/system/version"]);

--- a/src/components/mixins/SystemVersion.vue
+++ b/src/components/mixins/SystemVersion.vue
@@ -7,5 +7,8 @@ export default {
       return match ? match[0] : "2.1.8";
     },
   },
+  mounted() {
+    this.$root.doSubscribe(["openWB/system/version"]);
+  },
 };
 </script>

--- a/src/components/mixins/SystemVersion.vue
+++ b/src/components/mixins/SystemVersion.vue
@@ -1,0 +1,11 @@
+<script>
+export default {
+  computed: {
+    systemVersion() {
+      const version = this.$store.state.mqtt["openWB/system/version"];
+      const match = version?.match(/\d+\.\d+\.\d+/);
+      return match ? match[0] : "2.1.8";
+    },
+  },
+};
+</script>

--- a/src/components/vehicles/VehicleConfigMixin.vue
+++ b/src/components/vehicles/VehicleConfigMixin.vue
@@ -5,13 +5,6 @@ export default {
     vehicle: { required: true, type: Object },
   },
   emits: ["update:configuration"],
-  computed: {
-    systemVersion() {
-      const version = this.$store.state.mqtt["openWB/system/version"];
-      const match = version?.match(/^\d+\.\d+\.\d+/);
-      return match ? match[0] : "2.1.8";
-    },
-  },
   methods: {
     updateConfiguration(event, path = undefined) {
       this.$emit("update:configuration", { value: event, object: path });

--- a/src/components/vehicles/manual/vehicle.vue
+++ b/src/components/vehicles/manual/vehicle.vue
@@ -34,9 +34,10 @@
 
 <script>
 import VehicleConfigMixin from "../VehicleConfigMixin.vue";
+import SystemVersion from "../../mixins/SystemVersion.vue";
 
 export default {
   name: "VehicleSocManual",
-  mixins: [VehicleConfigMixin],
+  mixins: [VehicleConfigMixin, SystemVersion],
 };
 </script>

--- a/src/views/ChargePointInstallation.vue
+++ b/src/views/ChargePointInstallation.vue
@@ -475,6 +475,7 @@ import { FontAwesomeIcon, FontAwesomeLayers } from "@fortawesome/vue-fontawesome
 library.add(fasPlus, fasTrash, fasCopy, fasCalendarDay, fasCalendarAlt, fasCalendarWeek, fasChargingStation, farFile);
 
 import ComponentState from "../components/mixins/ComponentState.vue";
+import SystemVersion from "../components/mixins/SystemVersion.vue";
 import OpenwbChargePointProxy from "../components/charge_points/OpenwbChargePointProxy.vue";
 import TemplateAutoLockPlan from "../components/charge_points/TemplateAutoLockPlan.vue";
 
@@ -486,7 +487,7 @@ export default {
     OpenwbChargePointProxy,
     TemplateAutoLockPlan,
   },
-  mixins: [ComponentState],
+  mixins: [ComponentState, SystemVersion],
   props: {
     installAssistantActive: {
       type: Boolean,

--- a/src/views/GeneralConfiguration.vue
+++ b/src/views/GeneralConfiguration.vue
@@ -795,6 +795,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 library.add(fasCar, fasChargingStation, fasClock, fasCalendar, fasCoins, fasPieChart);
 import ComponentState from "../components/mixins/ComponentState.vue";
+import SystemVersion from "../components/mixins/SystemVersion.vue";
 import OpenwbWebThemeProxy from "../components/web_themes/OpenwbWebThemeProxy.vue";
 
 export default {
@@ -803,7 +804,7 @@ export default {
     OpenwbWebThemeProxy,
     FontAwesomeIcon,
   },
-  mixins: [ComponentState],
+  mixins: [ComponentState, SystemVersion],
   props: {
     installAssistantActive: {
       type: Boolean,

--- a/src/views/IdentificationConfiguration.vue
+++ b/src/views/IdentificationConfiguration.vue
@@ -244,10 +244,11 @@
 
 <script>
 import ComponentState from "../components/mixins/ComponentState.vue";
+import SystemVersion from "../components/mixins/SystemVersion.vue";
 
 export default {
   name: "IdentificationConfigView",
-  mixins: [ComponentState],
+  mixins: [ComponentState, SystemVersion],
   emits: ["save", "reset", "defaults"],
   data() {
     return {

--- a/src/views/SurplusChargeConfiguration.vue
+++ b/src/views/SurplusChargeConfiguration.vue
@@ -248,6 +248,7 @@
 
 <script>
 import ComponentState from "../components/mixins/ComponentState.vue";
+import SystemVersion from "../components/mixins/SystemVersion.vue";
 
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {
@@ -261,7 +262,7 @@ library.add(fasCarBattery, fasCarSide, fasBatteryHalf);
 export default {
   name: "OpenwbSurplusChargeConfigView",
   components: {},
-  mixins: [ComponentState],
+  mixins: [ComponentState, SystemVersion],
   emits: ["save", "reset", "defaults"],
   data() {
     return {


### PR DESCRIPTION
Die Logik zur Ermittlung der systemVersion wurde in ein eigenes Mixin ausgelagert (SystemVersion.vue) und in den betroffenen Komponenten eingebunden.

Not all Komponenten requiring systemVersion use ComponentState.vue, which previously led to duplication across mixins.
Centralizing the logic in a single mixin improves reusability and avoids duplication.