### PR TITLE
Fix chart legend

### DIFF
--- a/src/components/chart/LegendCategory.vue
+++ b/src/components/chart/LegendCategory.vue
@@ -8,7 +8,7 @@
     >
       {{ label }}
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu legend-dropdown-scroll">
       <li
         v-for="item in items"
         :key="item.label"
@@ -62,5 +62,9 @@ export default {
 }
 .legend-item-hidden {
   opacity: 0.5;
+}
+.legend-dropdown-scroll {
+  max-height: 500px;
+  overflow-y: auto;
 }
 </style>

--- a/src/components/chart/LegendCategory.vue
+++ b/src/components/chart/LegendCategory.vue
@@ -8,7 +8,7 @@
     >
       {{ label }}
     </button>
-    <ul class="dropdown-menu legend-dropdown-scroll">
+    <ul class="dropdown-menu legend-dropdown">
       <li
         v-for="item in items"
         :key="item.label"
@@ -63,8 +63,22 @@ export default {
 .legend-item-hidden {
   opacity: 0.5;
 }
-.legend-dropdown-scroll {
+.legend-dropdown {
   max-height: 30rem;
   overflow-y: auto;
+}
+
+@media (min-width: 1200px) {
+  .legend-dropdown {
+    max-height: 30rem;
+    overflow-y: auto;
+    column-count: 2;
+    column-gap: 0;
+  }
+
+  .legend-dropdown .dropdown-item {
+    display: inline-block;
+    width: 100%;
+  }
 }
 </style>

--- a/src/components/chart/LegendCategory.vue
+++ b/src/components/chart/LegendCategory.vue
@@ -67,18 +67,4 @@ export default {
   max-height: 45vh;
   overflow-y: auto;
 }
-
-@media (min-width: 1200px) {
-  .legend-dropdown {
-    max-height: 45vh;
-    overflow-y: auto;
-    column-count: 2;
-    column-gap: 0;
-  }
-
-  .legend-dropdown .dropdown-item {
-    display: inline-block;
-    width: 100%;
-  }
-}
 </style>

--- a/src/components/chart/LegendCategory.vue
+++ b/src/components/chart/LegendCategory.vue
@@ -64,7 +64,7 @@ export default {
   opacity: 0.5;
 }
 .legend-dropdown-scroll {
-  max-height: 500px;
+  max-height: 30rem;
   overflow-y: auto;
 }
 </style>

--- a/src/components/chart/LegendCategory.vue
+++ b/src/components/chart/LegendCategory.vue
@@ -64,7 +64,7 @@ export default {
   opacity: 0.5;
 }
 .legend-dropdown {
-  max-height: 75vh;
+  max-height: 45vh;
   overflow-y: auto;
 }
 

--- a/src/components/chart/LegendCategory.vue
+++ b/src/components/chart/LegendCategory.vue
@@ -64,13 +64,13 @@ export default {
   opacity: 0.5;
 }
 .legend-dropdown {
-  max-height: 30rem;
+  max-height: 75vh;
   overflow-y: auto;
 }
 
 @media (min-width: 1200px) {
   .legend-dropdown {
-    max-height: 30rem;
+    max-height: 45vh;
     overflow-y: auto;
     column-count: 2;
     column-gap: 0;


### PR DESCRIPTION
Problem:
Bei vielen Einträgen in der Legende sind nicht alle Elemente sichtbar bzw. erreichbar, da das Dropdown aktuell kein Scrollen unterstützt.

Lösungsoptionen:
	1.	Scrollable Dropdown (alle Bildschirmgrößen):
Das Dropdown wird auf eine maximale Höhe begrenzt und ist vertikal scrollbar.
→ Funktioniert zuverlässig auch auf mobilen Geräten.

**Commit: cae9942**


	2.	Responsive Variante:
	•	< 1200px: Scrollbares Dropdown (wie Option 1)
	•	≥ 1200px: Darstellung in zwei Spalten (kompakter), zusätzlich weiterhin scrollbar bei Bedarf
→ Bessere Nutzung des Platzes auf großen Bildschirmen.

**Commit: 4853a92**

<img width="1771" height="1017" alt="Bildschirmfoto 2026-04-13 um 11 07 54" src="https://github.com/user-attachments/assets/0164fb44-61ad-412f-9694-e380594816df" />

<img width="1193" height="888" alt="Bildschirmfoto 2026-04-13 um 11 50 04" src="https://github.com/user-attachments/assets/f65aa6dc-d992-4a62-ad7f-16501c584d3c" />

<img width="1268" height="887" alt="Bildschirmfoto 2026-04-13 um 11 35 39" src="https://github.com/user-attachments/assets/a017f06e-4503-4654-b434-c8be2eddd308" />
