### PR TITLE
fix: switch qcells battery control to mode 1 with dynamic timing; mod…

### DIFF
--- a/src/components/devices/qcells/qcells/bat.vue
+++ b/src/components/devices/qcells/qcells/bat.vue
@@ -2,11 +2,12 @@
   <div class="device-qcells-bat">
     <openwb-base-alert subtype="info">
       Die aktive Speichersteuerung erfolgt über das Solax Remote Control
-      Modbus-Protokoll (Mode 8).<br />
-      Unterstützte Hardware: QCells Q.VOLT HYB-G3-3P (Solax Gen4),
-      Solax Gen4/Gen5/Gen6 Hybrid und AC Wechselrichter.<br />
-      Gen2/Gen3 Wechselrichter werden nicht unterstützt, da diese kein
-      Remote Control unterstützen.<br />
+      Modbus-Protokoll (Mode 1, Active Power Control).<br />
+      Unterstützte Hardware: QCells Q.VOLT HYB-G3-3P (Solax Gen4).<br />
+      openWB berechnet den Sollwert aus Hauslast und PV-Leistung.<br />
+      Damit bei 0W Speicher-Sollwert die Batterie nicht entlädt, muss die
+      Hausanschlussgrenze am EVU-Zähler (max_total_power) korrekt gesetzt
+      sein.<br />
       Bitte die Felder "Maximale Ladeleistung" und "Maximale
       Entladeleistung" unter Ladeeinstellungen &gt; Speichersteuerung
       entsprechend der Leistungsfähigkeit des Wechselrichters und der


### PR DESCRIPTION
Remote Control Mode 8 was unstable, so we switched to Mode 1, which runs stably via HA. Mode 1 requires additional calculations because battery discharge is controlled based on potential power consumption.