### PR TITLE
active bat control: decrease step size of charge/ discharge power

### DIFF
--- a/src/views/ActiveBatControlConfiguration.vue
+++ b/src/views/ActiveBatControlConfiguration.vue
@@ -300,8 +300,8 @@
                 </template>
                 <openwb-base-number-input
                   title="Maximale Entladeleistung"
-                  :min="0.1"
-                  :step="0.1"
+                  :min="0.01"
+                  :step="0.01"
                   unit="kW"
                   required
                   :model-value="
@@ -313,8 +313,8 @@
                 />
                 <openwb-base-number-input
                   title="Maximale Ladeleistung"
-                  :min="0.1"
-                  :step="0.1"
+                  :min="0.01"
+                  :step="0.01"
                   unit="kW"
                   required
                   :model-value="$store.state.mqtt['openWB/bat/' + batteryConfig.id + '/get/max_charge_power'] / 1000"


### PR DESCRIPTION
Die maximale Lade- und Entladeleistung soll mit 2 Nachkommastellen angegeben werden können