### PR TITLE
Link Consumer-Counter in Load management structure

### DIFF
--- a/src/components/OpenwbNestedList.vue
+++ b/src/components/OpenwbNestedList.vue
@@ -52,11 +52,20 @@
               @click.stop="$emit('delete-group', element.id)"
             />
           </span>
+          <span
+            v-else-if="linkedMeterName(element.id)"
+            class="element-linked-meter"
+            :title="linkedMeterName(element.id)"
+          >
+            <span class="linked-meter-name">{{ linkedMeterName(element.id) }}</span>
+            <font-awesome-icon :icon="['fas', 'link']" />
+          </span>
         </div>
         <openwb-nested-list
           v-if="nesting && element.children && currentNestingDepth < maxNestingDepth"
           v-model="element.children"
           :labels="labels"
+          :linked-meters="linkedMeters"
           :nesting="nesting"
           :max-nesting-depth="maxNestingDepth"
           :current-nesting-depth="currentNestingDepth + 1"
@@ -82,6 +91,7 @@ import {
   faPen as fasPen,
   faCar as fasCar,
   faPlug as fasPlug,
+  faLink as fasLink,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
@@ -96,6 +106,7 @@ library.add(
   fasPen,
   fasCar,
   fasPlug,
+  fasLink,
 );
 export default {
   name: "OpenwbNestedList",
@@ -106,6 +117,7 @@ export default {
   props: {
     modelValue: { type: Array, required: false, default: () => [] },
     labels: { type: Object, required: false, default: undefined },
+    linkedMeters: { type: Object, required: false, default: undefined },
     nesting: { type: Boolean, default: true },
     maxNestingDepth: { type: Number, default: Infinity },
     currentNestingDepth: { type: Number, default: 0 },
@@ -166,6 +178,9 @@ export default {
         return this.labels[elementId];
       }
       return elementId;
+    },
+    linkedMeterName(elementId) {
+      return this.linkedMeters?.[elementId] ?? undefined;
     },
     getElementIcon(element) {
       switch (element.type) {
@@ -293,5 +308,26 @@ export default {
 
 .element-actions {
   cursor: pointer;
+}
+
+.element-linked-meter {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  margin-left: 8px;
+  opacity: 0.9;
+}
+
+.linked-meter-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 575.98px) {
+  .linked-meter-name {
+    display: none;
+  }
 }
 </style>

--- a/src/components/OpenwbNestedList.vue
+++ b/src/components/OpenwbNestedList.vue
@@ -8,7 +8,7 @@
     handle=".handle"
   >
     <template #item="{ element }">
-      <li>
+      <li v-show="!isHidden(element)">
         <div
           class="element-titel"
           :class="classes(element)"
@@ -66,6 +66,7 @@
           v-model="element.children"
           :labels="labels"
           :linked-meters="linkedMeters"
+          :hidden-ids="hiddenIds"
           :nesting="nesting"
           :max-nesting-depth="maxNestingDepth"
           :current-nesting-depth="currentNestingDepth + 1"
@@ -118,6 +119,7 @@ export default {
     modelValue: { type: Array, required: false, default: () => [] },
     labels: { type: Object, required: false, default: undefined },
     linkedMeters: { type: Object, required: false, default: undefined },
+    hiddenIds: { type: Array, required: false, default: undefined },
     nesting: { type: Boolean, default: true },
     maxNestingDepth: { type: Number, default: Infinity },
     currentNestingDepth: { type: Number, default: 0 },
@@ -181,6 +183,9 @@ export default {
     },
     linkedMeterName(elementId) {
       return this.linkedMeters?.[elementId] ?? undefined;
+    },
+    isHidden(element) {
+      return element.type === "counter" && !!this.hiddenIds?.some((id) => String(id) === String(element.id));
     },
     getElementIcon(element) {
       switch (element.type) {

--- a/src/components/OpenwbSortableList.vue
+++ b/src/components/OpenwbSortableList.vue
@@ -15,6 +15,7 @@
       v-if="value !== undefined"
       v-model="value"
       :labels="labels"
+      :linked-meters="linkedMeters"
       :nesting="nesting"
       :max-nesting-depth="maxNestingDepth"
       @delete-group="$emit('delete-group', $event)"
@@ -39,6 +40,7 @@ export default {
     title: { type: String, required: false, default: "" },
     modelValue: { type: Array, required: false, default: undefined },
     labels: { type: Object, default: undefined },
+    linkedMeters: { type: Object, default: undefined },
     nesting: { type: Boolean, default: true },
     maxNestingDepth: { type: Number, default: Infinity },
   },

--- a/src/components/OpenwbSortableList.vue
+++ b/src/components/OpenwbSortableList.vue
@@ -16,6 +16,7 @@
       v-model="value"
       :labels="labels"
       :linked-meters="linkedMeters"
+      :hidden-ids="hiddenIds"
       :nesting="nesting"
       :max-nesting-depth="maxNestingDepth"
       @delete-group="$emit('delete-group', $event)"
@@ -41,6 +42,7 @@ export default {
     modelValue: { type: Array, required: false, default: undefined },
     labels: { type: Object, default: undefined },
     linkedMeters: { type: Object, default: undefined },
+    hiddenIds: { type: Array, default: undefined },
     nesting: { type: Boolean, default: true },
     maxNestingDepth: { type: Number, default: Infinity },
   },

--- a/src/views/LoadManagementConfiguration.vue
+++ b/src/views/LoadManagementConfiguration.vue
@@ -222,12 +222,12 @@
           </openwb-base-alert>
         </div>
         <div v-else>
-          <!-- ToDo: Fix: nested lists bypass store commits! -->
           <sortable-list
             title="Anordnung der Komponenten"
-            :model-value="$store.state.mqtt['openWB/counter/get/hierarchy']"
+            :model-value="hierarchyWorkingCopy"
             :labels="hierarchyLabels"
-            @update:model-value="updateState('openWB/counter/get/hierarchy', $event)"
+            :linked-meters="consumerLinkedMeterNames"
+            @update:model-value="hierarchyWorkingCopy = $event"
           >
             <template #help>
               Durch die Anordnung der Komponenten werden Abhängigkeiten abgebildet.<br />
@@ -314,6 +314,7 @@ export default {
         { topic: "openWB/bat/+/config/max_power", writeable: true },
         { topic: "openWB/chargepoint/+/config", writeable: false },
         { topic: "openWB/consumer/+/module", writeable: false },
+        { topic: "openWB/consumer/+/extra_meter", writeable: false },
         { topic: "openWB/counter/+/config/max_currents", writeable: true },
         { topic: "openWB/counter/+/config/max_power_errorcase", writeable: true },
         { topic: "openWB/counter/+/config/max_total_power", writeable: true },
@@ -327,6 +328,11 @@ export default {
         { topic: "openWB/system/device/+/component/+/config", writeable: false },
       ],
       newGroupName: null,
+      // local, mutable copy of the (filtered) hierarchy that the sortable list drags in place;
+      // committed to the store via a deep watcher so nested reorders are persisted too
+      hierarchyWorkingCopy: null,
+      hierarchySeeded: false,
+      skipHierarchyCommit: false,
     };
   },
   computed: {
@@ -391,6 +397,56 @@ export default {
         return labels;
       },
     },
+    extraMeterLinks() {
+      const topics = this.getWildcardTopics("openWB/consumer/+/extra_meter") || {};
+      const links = [];
+      for (const [topic, counterId] of Object.entries(topics)) {
+        if (counterId === null || counterId === undefined) continue;
+        const match = topic.match(/^openWB\/consumer\/([^/]+)\/extra_meter$/);
+        if (!match) continue;
+        links.push({ consumerId: String(match[1]), counterId: String(counterId) });
+      }
+      return links;
+    },
+    linkedCounterIds() {
+      return new Set(this.extraMeterLinks.map((link) => link.counterId));
+    },
+    consumerLinkedMeterNames() {
+      const names = {};
+      for (const { consumerId, counterId } of this.extraMeterLinks) {
+        const component = this.getComponent(counterId);
+        names[consumerId] = component?.name ?? counterId;
+      }
+      return names;
+    },
+    // Store hierarchy with linked counters removed. Used to seed the local working copy that the
+    // sortable list mutates; the hidden counters are re-inserted on commit via reconcileHierarchy.
+    filteredStoreHierarchy() {
+      const hierarchy = this.$store.state.mqtt["openWB/counter/get/hierarchy"];
+      if (!Array.isArray(hierarchy) || this.linkedCounterIds.size === 0) return hierarchy;
+      const linked = this.linkedCounterIds;
+      const filter = (nodes) => {
+        let changed = false;
+        const out = [];
+        for (const node of nodes) {
+          if (node.type === "counter" && linked.has(String(node.id))) {
+            changed = true;
+            continue;
+          }
+          if (Array.isArray(node.children)) {
+            const newChildren = filter(node.children);
+            if (newChildren !== node.children) {
+              out.push({ ...node, children: newChildren });
+              changed = true;
+              continue;
+            }
+          }
+          out.push(node);
+        }
+        return changed ? out : nodes;
+      };
+      return filter(hierarchy);
+    },
     loadManagementPriorityList: {
       get() {
         const priorityList = this.$store.state.mqtt["openWB/counter/get/loadmanagement_prios"] || [];
@@ -454,6 +510,35 @@ export default {
       return { options: options, groups: groups };
     },
   },
+  watch: {
+    // Seed the working copy once the (filtered) store hierarchy is available. Re-seed only when
+    // the store value diverges from the working copy (e.g. an external update), never as an echo
+    // of our own commit, so we do not create a commit loop.
+    filteredStoreHierarchy: {
+      immediate: true,
+      handler(filtered) {
+        if (!Array.isArray(filtered)) return;
+        if (this.hierarchySeeded && JSON.stringify(filtered) === JSON.stringify(this.hierarchyWorkingCopy)) {
+          return;
+        }
+        this.skipHierarchyCommit = true;
+        this.hierarchyWorkingCopy = JSON.parse(JSON.stringify(filtered));
+        this.hierarchySeeded = true;
+        this.$nextTick(() => {
+          this.skipHierarchyCommit = false;
+        });
+      },
+    },
+    // Persist any drag (top-level or nested) by re-inserting the hidden linked counters and
+    // committing the full hierarchy to the store.
+    hierarchyWorkingCopy: {
+      deep: true,
+      handler(copy) {
+        if (this.skipHierarchyCommit || !Array.isArray(copy)) return;
+        this.updateState("openWB/counter/get/hierarchy", this.reconcileHierarchy(copy));
+      },
+    },
+  },
   methods: {
     getElementTreeNames(element) {
       let myNames = {};
@@ -504,6 +589,49 @@ export default {
     },
     isComponentType(componentType, verifier) {
       return componentType?.split("_").includes(verifier);
+    },
+    reconcileHierarchy(newList) {
+      const storeHierarchy = this.$store.state.mqtt["openWB/counter/get/hierarchy"];
+      if (!Array.isArray(storeHierarchy) || this.linkedCounterIds.size === 0) {
+        return newList;
+      }
+      const linked = this.linkedCounterIds;
+      const hidden = [];
+      const collect = (nodes, parentId) => {
+        nodes.forEach((node, index) => {
+          if (node.type === "counter" && linked.has(String(node.id))) {
+            hidden.push({ node: JSON.parse(JSON.stringify(node)), parentId, index });
+          }
+          if (Array.isArray(node.children)) {
+            collect(node.children, String(node.id));
+          }
+        });
+      };
+      collect(storeHierarchy, null);
+
+      const result = JSON.parse(JSON.stringify(newList));
+      const findChildren = (nodes, parentId) => {
+        for (const node of nodes) {
+          if (String(node.id) === parentId) {
+            if (!Array.isArray(node.children)) node.children = [];
+            return node.children;
+          }
+          if (Array.isArray(node.children)) {
+            const found = findChildren(node.children, parentId);
+            if (found) return found;
+          }
+        }
+        return null;
+      };
+      hidden.forEach(({ node, parentId, index }) => {
+        const target = parentId === null ? result : findChildren(result, parentId);
+        if (!target) {
+          result.push(node);
+          return;
+        }
+        target.splice(Math.min(index, target.length), 0, node);
+      });
+      return result;
     },
     addLoadManagementPriorityGroup() {
       if (!this.newGroupName) return;

--- a/src/views/LoadManagementConfiguration.vue
+++ b/src/views/LoadManagementConfiguration.vue
@@ -224,10 +224,11 @@
         <div v-else>
           <sortable-list
             title="Anordnung der Komponenten"
-            :model-value="hierarchyWorkingCopy"
+            :model-value="$store.state.mqtt['openWB/counter/get/hierarchy']"
             :labels="hierarchyLabels"
             :linked-meters="consumerLinkedMeterNames"
-            @update:model-value="hierarchyWorkingCopy = $event"
+            :hidden-ids="hiddenCounterIds"
+            @update:model-value="updateState('openWB/counter/get/hierarchy', $event)"
           >
             <template #help>
               Durch die Anordnung der Komponenten werden Abhängigkeiten abgebildet.<br />
@@ -328,11 +329,6 @@ export default {
         { topic: "openWB/system/device/+/component/+/config", writeable: false },
       ],
       newGroupName: null,
-      // local, mutable copy of the (filtered) hierarchy that the sortable list drags in place;
-      // committed to the store via a deep watcher so nested reorders are persisted too
-      hierarchyWorkingCopy: null,
-      hierarchySeeded: false,
-      skipHierarchyCommit: false,
     };
   },
   computed: {
@@ -408,8 +404,8 @@ export default {
       }
       return links;
     },
-    linkedCounterIds() {
-      return new Set(this.extraMeterLinks.map((link) => link.counterId));
+    hiddenCounterIds() {
+      return Array.from(new Set(this.extraMeterLinks.map((link) => link.counterId)));
     },
     consumerLinkedMeterNames() {
       const names = {};
@@ -418,34 +414,6 @@ export default {
         names[consumerId] = component?.name ?? counterId;
       }
       return names;
-    },
-    // Store hierarchy with linked counters removed. Used to seed the local working copy that the
-    // sortable list mutates; the hidden counters are re-inserted on commit via reconcileHierarchy.
-    filteredStoreHierarchy() {
-      const hierarchy = this.$store.state.mqtt["openWB/counter/get/hierarchy"];
-      if (!Array.isArray(hierarchy) || this.linkedCounterIds.size === 0) return hierarchy;
-      const linked = this.linkedCounterIds;
-      const filter = (nodes) => {
-        let changed = false;
-        const out = [];
-        for (const node of nodes) {
-          if (node.type === "counter" && linked.has(String(node.id))) {
-            changed = true;
-            continue;
-          }
-          if (Array.isArray(node.children)) {
-            const newChildren = filter(node.children);
-            if (newChildren !== node.children) {
-              out.push({ ...node, children: newChildren });
-              changed = true;
-              continue;
-            }
-          }
-          out.push(node);
-        }
-        return changed ? out : nodes;
-      };
-      return filter(hierarchy);
     },
     loadManagementPriorityList: {
       get() {
@@ -510,35 +478,6 @@ export default {
       return { options: options, groups: groups };
     },
   },
-  watch: {
-    // Seed the working copy once the (filtered) store hierarchy is available. Re-seed only when
-    // the store value diverges from the working copy (e.g. an external update), never as an echo
-    // of our own commit, so we do not create a commit loop.
-    filteredStoreHierarchy: {
-      immediate: true,
-      handler(filtered) {
-        if (!Array.isArray(filtered)) return;
-        if (this.hierarchySeeded && JSON.stringify(filtered) === JSON.stringify(this.hierarchyWorkingCopy)) {
-          return;
-        }
-        this.skipHierarchyCommit = true;
-        this.hierarchyWorkingCopy = JSON.parse(JSON.stringify(filtered));
-        this.hierarchySeeded = true;
-        this.$nextTick(() => {
-          this.skipHierarchyCommit = false;
-        });
-      },
-    },
-    // Persist any drag (top-level or nested) by re-inserting the hidden linked counters and
-    // committing the full hierarchy to the store.
-    hierarchyWorkingCopy: {
-      deep: true,
-      handler(copy) {
-        if (this.skipHierarchyCommit || !Array.isArray(copy)) return;
-        this.updateState("openWB/counter/get/hierarchy", this.reconcileHierarchy(copy));
-      },
-    },
-  },
   methods: {
     getElementTreeNames(element) {
       let myNames = {};
@@ -589,49 +528,6 @@ export default {
     },
     isComponentType(componentType, verifier) {
       return componentType?.split("_").includes(verifier);
-    },
-    reconcileHierarchy(newList) {
-      const storeHierarchy = this.$store.state.mqtt["openWB/counter/get/hierarchy"];
-      if (!Array.isArray(storeHierarchy) || this.linkedCounterIds.size === 0) {
-        return newList;
-      }
-      const linked = this.linkedCounterIds;
-      const hidden = [];
-      const collect = (nodes, parentId) => {
-        nodes.forEach((node, index) => {
-          if (node.type === "counter" && linked.has(String(node.id))) {
-            hidden.push({ node: JSON.parse(JSON.stringify(node)), parentId, index });
-          }
-          if (Array.isArray(node.children)) {
-            collect(node.children, String(node.id));
-          }
-        });
-      };
-      collect(storeHierarchy, null);
-
-      const result = JSON.parse(JSON.stringify(newList));
-      const findChildren = (nodes, parentId) => {
-        for (const node of nodes) {
-          if (String(node.id) === parentId) {
-            if (!Array.isArray(node.children)) node.children = [];
-            return node.children;
-          }
-          if (Array.isArray(node.children)) {
-            const found = findChildren(node.children, parentId);
-            if (found) return found;
-          }
-        }
-        return null;
-      };
-      hidden.forEach(({ node, parentId, index }) => {
-        const target = parentId === null ? result : findChildren(result, parentId);
-        if (!target) {
-          result.push(node);
-          return;
-        }
-        target.splice(Math.min(index, target.length), 0, node);
-      });
-      return result;
     },
     addLoadManagementPriorityGroup() {
       if (!this.newGroupName) return;

--- a/src/views/LoadManagementConfiguration.vue
+++ b/src/views/LoadManagementConfiguration.vue
@@ -243,7 +243,7 @@
           <hr />
           <sortable-list
             v-model="loadManagementPriorityList"
-            title="Prioritäten-Steuerung für das Lastmanagement"
+            title="Prioritätenliste"
             :labels="loadManagementPriorityLabels"
             :nesting="true"
             :max-nesting-depth="1"


### PR DESCRIPTION
Verbraucher können in ihren Einstellungen einen separaten Zähler zur Leistungsmessung verknüpfen (extra_meter). Bisher wurde ein solcher Zähler zusätzlich als eigene Zeile in der Komponenten-Anordnung ("Struktur") angezeigt, obwohl er fest zu einem Verbraucher gehört.

Ist ein Zähler mit einem Verbraucher verknüpft, wird seine Zeile in der Anordnung der Komponenten ausgeblendet.

Der zugehörige Verbraucher erhält stattdessen ein Link-Symbol mit dem Namen des verknüpften Zählers am rechten Rand seiner Kopfzeile.

Der Zähler bleibt dabei unverändert Teil der Hierarchie-Daten – er wird lediglich per v-show in der Anzeige verborgen. 

Zusätzlich: Titel der Prioritätenliste umbenannt.

<img width="1141" height="785" alt="Bildschirmfoto vom 2026-07-03 08-12-46" src="https://github.com/user-attachments/assets/248d9538-d9b7-4dd2-8e7e-71b9fdd2c66a" />

<img width="1124" height="1130" alt="Bildschirmfoto vom 2026-07-03 08-18-24" src="https://github.com/user-attachments/assets/f0c2cf5e-6ba2-4461-a007-25cc060ced88" />
