### PR TITLE
Add consumer status cards

### DIFF
--- a/src/components/mixins/LoadManagementPriority.vue
+++ b/src/components/mixins/LoadManagementPriority.vue
@@ -1,19 +1,29 @@
 <script>
 // Shared helpers to read an element's rank from the load management priority
 // list (openWB/counter/get/loadmanagement_prios).
+const LOADMANAGEMENT_PRIOS_TOPIC = "openWB/counter/get/loadmanagement_prios";
+
 export default {
   name: "LoadManagementPriority",
-  methods: {
+  computed: {
     loadManagementPriorityList() {
-      const list = this.$store.state.mqtt["openWB/counter/get/loadmanagement_prios"];
+      const list = this.$store.state.mqtt[LOADMANAGEMENT_PRIOS_TOPIC];
       return Array.isArray(list) ? list : [];
     },
+  },
+  mounted() {
+    this.$root.doSubscribe([LOADMANAGEMENT_PRIOS_TOPIC]);
+  },
+  unmounted() {
+    this.$root.doUnsubscribe([LOADMANAGEMENT_PRIOS_TOPIC]);
+  },
+  methods: {
     // matches an entry against the requested type/id
     matchesPriorityEntry(entry, type, id) {
       return entry.type === type && String(entry.id) === String(id);
     },
     loadManagementPriority(type, id) {
-      const list = this.loadManagementPriorityList();
+      const list = this.loadManagementPriorityList;
       for (let rank = 0; rank < list.length; rank++) {
         const entry = list[rank];
         if (entry.type === "group") {
@@ -27,7 +37,7 @@ export default {
       return null;
     },
     loadManagementPriorityShared(type, id) {
-      const list = this.loadManagementPriorityList();
+      const list = this.loadManagementPriorityList;
       for (const entry of list) {
         if (entry.type === "group") {
           const children = entry.children ?? [];

--- a/src/components/mixins/LoadManagementPriority.vue
+++ b/src/components/mixins/LoadManagementPriority.vue
@@ -1,0 +1,43 @@
+<script>
+// Shared helpers to read an element's rank from the load management priority
+// list (openWB/counter/get/loadmanagement_prios).
+export default {
+  name: "LoadManagementPriority",
+  methods: {
+    loadManagementPriorityList() {
+      const list = this.$store.state.mqtt["openWB/counter/get/loadmanagement_prios"];
+      return Array.isArray(list) ? list : [];
+    },
+    // matches an entry against the requested type/id
+    matchesPriorityEntry(entry, type, id) {
+      return entry.type === type && String(entry.id) === String(id);
+    },
+    loadManagementPriority(type, id) {
+      const list = this.loadManagementPriorityList();
+      for (let rank = 0; rank < list.length; rank++) {
+        const entry = list[rank];
+        if (entry.type === "group") {
+          if ((entry.children ?? []).some((child) => this.matchesPriorityEntry(child, type, id))) {
+            return rank + 1;
+          }
+        } else if (this.matchesPriorityEntry(entry, type, id)) {
+          return rank + 1;
+        }
+      }
+      return null;
+    },
+    loadManagementPriorityShared(type, id) {
+      const list = this.loadManagementPriorityList();
+      for (const entry of list) {
+        if (entry.type === "group") {
+          const children = entry.children ?? [];
+          if (children.some((child) => this.matchesPriorityEntry(child, type, id))) {
+            return children.length > 1;
+          }
+        }
+      }
+      return false;
+    },
+  },
+};
+</script>

--- a/src/components/status/ConsumerCard.vue
+++ b/src/components/status/ConsumerCard.vue
@@ -1,0 +1,246 @@
+<template>
+  <status-card
+    subtype="purple"
+    :component-id="consumerId"
+    :state="$store.state.mqtt[baseTopic + '/get/fault_state']"
+    :state-message="$store.state.mqtt[baseTopic + '/get/fault_str']"
+  >
+    <template #header-left>
+      <font-awesome-icon :icon="['fas', 'plug']" />
+      {{ name }}
+    </template>
+    <template #header-right>
+      <span
+        v-if="priority !== null"
+        class="badge badge-pill badge-light mr-2"
+        title="Rangfolge in der Prioritäten-Steuerung"
+      >
+        Prio {{ priority }}
+      </span>
+      {{ power }}&nbsp;kW
+    </template>
+    <openwb-base-card
+      title="Aktuelle Werte"
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+    >
+      <div class="row">
+        <div class="col pr-0 text-right">Leistung</div>
+        <div class="col text-right text-monospace">{{ power }}&nbsp;kW</div>
+      </div>
+      <div class="row">
+        <div class="col pr-0 text-right">Status</div>
+        <div class="col text-right text-monospace">{{ statusText }}</div>
+      </div>
+      <div
+        v-if="chargemode !== null"
+        class="row"
+      >
+        <div class="col pr-0 text-right">Betriebsmodus</div>
+        <div class="col text-right text-monospace">{{ chargemode }}</div>
+      </div>
+    </openwb-base-card>
+    <openwb-base-card
+      v-if="priority !== null"
+      title="Priorität"
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+    >
+      <div class="row">
+        <div class="col pr-0 text-right">Rangfolge</div>
+        <div class="col text-right text-monospace">Prio {{ priority }}</div>
+      </div>
+      <div
+        v-if="prioritySharedGroup"
+        class="row"
+      >
+        <div class="col text-right">
+          <small>Gleichrangig mit anderen Geräten der selben Gruppe.</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col text-right">
+          <small>Die Rangfolge lässt sich unter „Lastmanagement“ anpassen.</small>
+        </div>
+      </div>
+    </openwb-base-card>
+    <openwb-base-card
+      v-if="hasMeterData"
+      title="Zählerstände"
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+    >
+      <div class="row justify-content-end">
+        <div class="col-4 text-right">Import</div>
+        <div class="col-4 text-right">Export</div>
+      </div>
+      <div class="row">
+        <div class="col text-right">Heute</div>
+        <div class="col-4 text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/daily_imported", 3, 3, 0.001) }}&nbsp;kWh
+        </div>
+        <div class="col-4 text-right text-monospace">-</div>
+      </div>
+      <div class="row">
+        <div class="col text-right">Gesamt</div>
+        <div class="col-4 text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/imported", 3, 3, 0.001) }}&nbsp;kWh
+        </div>
+        <div class="col-4 text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/exported", 3, 3, 0.001) }}&nbsp;kWh
+        </div>
+      </div>
+    </openwb-base-card>
+    <openwb-base-card
+      v-if="hasPhaseData"
+      title="Werte pro Phase"
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+    >
+      <div class="row">
+        <div class="col-md-4 pr-0 text-center text-md-right">Spannung [V]</div>
+        <div class="col">
+          <div class="row">
+            <div
+              v-for="(value, index) in formatPhaseArrayNumberTopic(baseTopic + '/get/voltages', 1)"
+              :key="index"
+              class="col text-right text-monospace pl-0"
+            >
+              {{ value }}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4 pr-0 text-center text-md-right">Strom [A]</div>
+        <div class="col">
+          <div class="row">
+            <div
+              v-for="(value, index) in formatPhaseArrayNumberTopic(baseTopic + '/get/currents', 2)"
+              :key="index"
+              class="col text-right text-monospace pl-0"
+            >
+              {{ value }}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4 pr-0 text-center text-md-right">Leistung [kW]</div>
+        <div class="col">
+          <div class="row">
+            <div
+              v-for="(value, index) in formatPhaseArrayNumberTopic(baseTopic + '/get/powers', 3, 3, 0.001)"
+              :key="index"
+              class="col text-right text-monospace pl-0"
+            >
+              {{ value }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </openwb-base-card>
+  </status-card>
+</template>
+
+<script>
+import ComponentState from "../mixins/ComponentState.vue";
+import LoadManagementPriority from "../mixins/LoadManagementPriority.vue";
+import StatusCard from "./StatusCard.vue";
+
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faPlug as fasPlug } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+library.add(fasPlug);
+
+export default {
+  name: "ConsumerCard",
+  components: {
+    StatusCard,
+    FontAwesomeIcon,
+  },
+  mixins: [ComponentState, LoadManagementPriority],
+  props: {
+    consumerId: { type: Number, required: true },
+  },
+  data() {
+    return {
+      mqttTopics: [
+        { topic: `openWB/consumer/${this.consumerId}/module`, writeable: false },
+        { topic: `openWB/consumer/${this.consumerId}/usage`, writeable: false },
+        { topic: `openWB/consumer/${this.consumerId}/get/+`, writeable: false },
+        { topic: "openWB/counter/get/loadmanagement_prios", writeable: false },
+      ],
+    };
+  },
+  computed: {
+    baseTopic: {
+      get() {
+        return `openWB/consumer/${this.consumerId}`;
+      },
+    },
+    name: {
+      get() {
+        const module = this.$store.state.mqtt[this.baseTopic + "/module"];
+        return module?.name ?? `Verbraucher ${this.consumerId}`;
+      },
+    },
+    power: {
+      get() {
+        return this.formatNumberTopic(this.baseTopic + "/get/power", 3, 3, 0.001);
+      },
+    },
+    statusText: {
+      get() {
+        const stateString = this.$store.state.mqtt[this.baseTopic + "/get/state_str"];
+        if (stateString) {
+          return stateString;
+        }
+        const state = this.$store.state.mqtt[this.baseTopic + "/get/state"];
+        if (state === undefined) {
+          return "-";
+        }
+        return state ? "Eingeschaltet" : "Ausgeschaltet";
+      },
+    },
+    chargemode: {
+      get() {
+        const usage = this.$store.state.mqtt[this.baseTopic + "/usage"];
+        if (!usage || usage.chargemode === undefined) {
+          return null;
+        }
+        return this.translateChargeMode(usage.chargemode);
+      },
+    },
+    priority: {
+      get() {
+        return this.loadManagementPriority("consumer", this.consumerId);
+      },
+    },
+    prioritySharedGroup: {
+      get() {
+        return this.loadManagementPriorityShared("consumer", this.consumerId);
+      },
+    },
+    hasMeterData: {
+      get() {
+        return (
+          this.$store.state.mqtt[this.baseTopic + "/get/imported"] !== undefined ||
+          this.$store.state.mqtt[this.baseTopic + "/get/exported"] !== undefined
+        );
+      },
+    },
+    hasPhaseData: {
+      get() {
+        const currents = this.$store.state.mqtt[this.baseTopic + "/get/currents"];
+        return Array.isArray(currents) && currents.length > 0;
+      },
+    },
+  },
+};
+</script>

--- a/src/components/status/ConsumerCard.vue
+++ b/src/components/status/ConsumerCard.vue
@@ -67,6 +67,27 @@
       </div>
     </openwb-base-card>
     <openwb-base-card
+      title="Separate Leistungsmessung"
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+    >
+      <div class="row">
+        <div class="col pr-0 text-right">Zähler</div>
+        <div class="col text-right text-monospace">
+          {{ hasExtraMeter ? extraMeterName : "keiner" }}
+        </div>
+      </div>
+      <div
+        v-if="hasExtraMeter"
+        class="row"
+      >
+        <div class="col text-right">
+          <small>Die angezeigten Leistungswerte stammen von diesem Zähler.</small>
+        </div>
+      </div>
+    </openwb-base-card>
+    <openwb-base-card
       v-if="hasPhaseData"
       title="Werte pro Phase"
       subtype="white"
@@ -146,6 +167,8 @@ export default {
         { topic: `openWB/consumer/${this.consumerId}/module`, writeable: false },
         { topic: `openWB/consumer/${this.consumerId}/usage`, writeable: false },
         { topic: `openWB/consumer/${this.consumerId}/get/+`, writeable: false },
+        { topic: `openWB/consumer/${this.consumerId}/extra_meter`, writeable: false },
+        { topic: "openWB/system/device/+/component/+/config", writeable: false },
         { topic: "openWB/counter/get/loadmanagement_prios", writeable: false },
       ],
     };
@@ -203,6 +226,28 @@ export default {
       get() {
         const currents = this.$store.state.mqtt[this.baseTopic + "/get/currents"];
         return Array.isArray(currents) && currents.length > 0;
+      },
+    },
+    extraMeterId: {
+      get() {
+        return this.$store.state.mqtt[this.baseTopic + "/extra_meter"] ?? null;
+      },
+    },
+    hasExtraMeter: {
+      get() {
+        return this.extraMeterId !== null;
+      },
+    },
+    extraMeterName: {
+      get() {
+        if (this.extraMeterId === null) {
+          return null;
+        }
+        const components = this.getWildcardTopics("openWB/system/device/+/component/+/config");
+        const component = Object.values(components).find(
+          (component) => component && component.id === this.extraMeterId,
+        );
+        return component?.name ?? `Zähler ${this.extraMeterId}`;
       },
     },
   },

--- a/src/components/status/ConsumerCard.vue
+++ b/src/components/status/ConsumerCard.vue
@@ -67,34 +67,6 @@
       </div>
     </openwb-base-card>
     <openwb-base-card
-      v-if="hasMeterData"
-      title="Zählerstände"
-      subtype="white"
-      body-bg="white"
-      class="py-1 mb-2"
-    >
-      <div class="row justify-content-end">
-        <div class="col-4 text-right">Import</div>
-        <div class="col-4 text-right">Export</div>
-      </div>
-      <div class="row">
-        <div class="col text-right">Heute</div>
-        <div class="col-4 text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/daily_imported", 3, 3, 0.001) }}&nbsp;kWh
-        </div>
-        <div class="col-4 text-right text-monospace">-</div>
-      </div>
-      <div class="row">
-        <div class="col text-right">Gesamt</div>
-        <div class="col-4 text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/imported", 3, 3, 0.001) }}&nbsp;kWh
-        </div>
-        <div class="col-4 text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/exported", 3, 3, 0.001) }}&nbsp;kWh
-        </div>
-      </div>
-    </openwb-base-card>
-    <openwb-base-card
       v-if="hasPhaseData"
       title="Werte pro Phase"
       subtype="white"
@@ -225,14 +197,6 @@ export default {
     prioritySharedGroup: {
       get() {
         return this.loadManagementPriorityShared("consumer", this.consumerId);
-      },
-    },
-    hasMeterData: {
-      get() {
-        return (
-          this.$store.state.mqtt[this.baseTopic + "/get/imported"] !== undefined ||
-          this.$store.state.mqtt[this.baseTopic + "/get/exported"] !== undefined
-        );
       },
     },
     hasPhaseData: {

--- a/src/components/status/ConsumerCard.vue
+++ b/src/components/status/ConsumerCard.vue
@@ -169,7 +169,6 @@ export default {
         { topic: `openWB/consumer/${this.consumerId}/get/+`, writeable: false },
         { topic: `openWB/consumer/${this.consumerId}/extra_meter`, writeable: false },
         { topic: "openWB/system/device/+/component/+/config", writeable: false },
-        { topic: "openWB/counter/get/loadmanagement_prios", writeable: false },
       ],
     };
   },

--- a/src/components/status/ConsumerSumCard.vue
+++ b/src/components/status/ConsumerSumCard.vue
@@ -5,7 +5,7 @@
       Alle Verbraucher
     </template>
     <template #header-right>
-      <span class="text-right"> {{ formatNumberTopic(baseTopic + "/get/power", 3, 3, 0.001) }}&nbsp;kW </span>
+      <span class="text-right"> {{ formatNumber(totalPower, 3, 3, 0.001) }}&nbsp;kW </span>
     </template>
     <openwb-base-card
       subtype="white"
@@ -15,38 +15,7 @@
     >
       <div class="row">
         <div class="col pr-0 text-right">Leistung</div>
-        <div class="col text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/power", 3, 3, 0.001) }}&nbsp;kW
-        </div>
-      </div>
-    </openwb-base-card>
-    <openwb-base-card
-      subtype="white"
-      body-bg="white"
-      class="py-1 mb-2"
-      title="Zählerstände"
-    >
-      <div class="row justify-content-end">
-        <div class="col-4 text-right">Import</div>
-        <div class="col-4 text-right">Export</div>
-      </div>
-      <div class="row">
-        <div class="col text-right">Heute</div>
-        <div class="col-4 text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/daily_imported", 3, 3, 0.001) }}&nbsp;kWh
-        </div>
-        <div class="col-4 text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/daily_exported", 3, 3, 0.001) }}&nbsp;kWh
-        </div>
-      </div>
-      <div class="row">
-        <div class="col text-right">Gesamt</div>
-        <div class="col-4 text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/imported", 3, 3, 0.001) }}&nbsp;kWh
-        </div>
-        <div class="col-4 text-right text-monospace">
-          {{ formatNumberTopic(baseTopic + "/get/exported", 3, 3, 0.001) }}&nbsp;kWh
-        </div>
+        <div class="col text-right text-monospace">{{ formatNumber(totalPower, 3, 3, 0.001) }}&nbsp;kW</div>
       </div>
     </openwb-base-card>
   </status-card>
@@ -71,19 +40,15 @@ export default {
   mixins: [ComponentState],
   data() {
     return {
-      mqttTopics: [
-        { topic: "openWB/consumer/get/power", writeable: false },
-        { topic: "openWB/consumer/get/imported", writeable: false },
-        { topic: "openWB/consumer/get/exported", writeable: false },
-        { topic: "openWB/consumer/get/daily_imported", writeable: false },
-        { topic: "openWB/consumer/get/daily_exported", writeable: false },
-      ],
+      mqttTopics: [{ topic: "openWB/consumer/+/get/power", writeable: false }],
     };
   },
   computed: {
-    baseTopic: {
+    totalPower: {
       get() {
-        return "openWB/consumer";
+        return Object.values(this.getWildcardTopics("openWB/consumer/+/get/power")).reduce((sum, power) => {
+          return sum + (typeof power === "number" ? power : 0);
+        }, 0);
       },
     },
   },

--- a/src/components/status/ConsumerSumCard.vue
+++ b/src/components/status/ConsumerSumCard.vue
@@ -1,0 +1,91 @@
+<template>
+  <status-card subtype="purple">
+    <template #header-left>
+      <font-awesome-icon :icon="['fas', 'plug']" />
+      Alle Verbraucher
+    </template>
+    <template #header-right>
+      <span class="text-right"> {{ formatNumberTopic(baseTopic + "/get/power", 3, 3, 0.001) }}&nbsp;kW </span>
+    </template>
+    <openwb-base-card
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+      title="Aktuelle Werte"
+    >
+      <div class="row">
+        <div class="col pr-0 text-right">Leistung</div>
+        <div class="col text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/power", 3, 3, 0.001) }}&nbsp;kW
+        </div>
+      </div>
+    </openwb-base-card>
+    <openwb-base-card
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+      title="Zählerstände"
+    >
+      <div class="row justify-content-end">
+        <div class="col-4 text-right">Import</div>
+        <div class="col-4 text-right">Export</div>
+      </div>
+      <div class="row">
+        <div class="col text-right">Heute</div>
+        <div class="col-4 text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/daily_imported", 3, 3, 0.001) }}&nbsp;kWh
+        </div>
+        <div class="col-4 text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/daily_exported", 3, 3, 0.001) }}&nbsp;kWh
+        </div>
+      </div>
+      <div class="row">
+        <div class="col text-right">Gesamt</div>
+        <div class="col-4 text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/imported", 3, 3, 0.001) }}&nbsp;kWh
+        </div>
+        <div class="col-4 text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/exported", 3, 3, 0.001) }}&nbsp;kWh
+        </div>
+      </div>
+    </openwb-base-card>
+  </status-card>
+</template>
+
+<script>
+import ComponentState from "../mixins/ComponentState.vue";
+import StatusCard from "./StatusCard.vue";
+
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faPlug as fasPlug } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+library.add(fasPlug);
+
+export default {
+  name: "ConsumerSumCard",
+  components: {
+    StatusCard,
+    FontAwesomeIcon,
+  },
+  mixins: [ComponentState],
+  data() {
+    return {
+      mqttTopics: [
+        { topic: "openWB/consumer/get/power", writeable: false },
+        { topic: "openWB/consumer/get/imported", writeable: false },
+        { topic: "openWB/consumer/get/exported", writeable: false },
+        { topic: "openWB/consumer/get/daily_imported", writeable: false },
+        { topic: "openWB/consumer/get/daily_exported", writeable: false },
+      ],
+    };
+  },
+  computed: {
+    baseTopic: {
+      get() {
+        return "openWB/consumer";
+      },
+    },
+  },
+};
+</script>

--- a/src/components/status/ConsumerSumCard.vue
+++ b/src/components/status/ConsumerSumCard.vue
@@ -5,7 +5,7 @@
       Alle Verbraucher
     </template>
     <template #header-right>
-      <span class="text-right"> {{ formatNumber(totalPower, 3, 3, 0.001) }}&nbsp;kW </span>
+      <span class="text-right"> {{ formatNumberTopic(baseTopic + "/get/power", 3, 3, 0.001) }}&nbsp;kW </span>
     </template>
     <openwb-base-card
       subtype="white"
@@ -15,7 +15,9 @@
     >
       <div class="row">
         <div class="col pr-0 text-right">Leistung</div>
-        <div class="col text-right text-monospace">{{ formatNumber(totalPower, 3, 3, 0.001) }}&nbsp;kW</div>
+        <div class="col text-right text-monospace">
+          {{ formatNumberTopic(baseTopic + "/get/power", 3, 3, 0.001) }}&nbsp;kW
+        </div>
       </div>
     </openwb-base-card>
   </status-card>
@@ -40,15 +42,13 @@ export default {
   mixins: [ComponentState],
   data() {
     return {
-      mqttTopics: [{ topic: "openWB/consumer/+/get/power", writeable: false }],
+      mqttTopics: [{ topic: "openWB/consumer/get/power", writeable: false }],
     };
   },
   computed: {
-    totalPower: {
+    baseTopic: {
       get() {
-        return Object.values(this.getWildcardTopics("openWB/consumer/+/get/power")).reduce((sum, power) => {
-          return sum + (typeof power === "number" ? power : 0);
-        }, 0);
+        return "openWB/consumer";
       },
     },
   },

--- a/src/components/status/VehicleCard.vue
+++ b/src/components/status/VehicleCard.vue
@@ -18,10 +18,17 @@
       {{ name }}
     </template>
     <template
-      v-if="soc != '-'"
+      v-if="soc != '-' || priority !== null"
       #header-right
     >
-      {{ soc }}&nbsp;%
+      <span
+        v-if="priority !== null"
+        class="badge badge-pill badge-light mr-2"
+        title="Rangfolge in der Prioritäten-Steuerung"
+      >
+        Prio {{ priority }}
+      </span>
+      <template v-if="soc != '-'">{{ soc }}&nbsp;%</template>
     </template>
     <!-- Fahrzeugdaten -->
     <openwb-base-card
@@ -63,11 +70,37 @@
         <div class="col text-right text-monospace">{{ socOdometer }}&nbsp;km</div>
       </div>
     </openwb-base-card>
+    <openwb-base-card
+      v-if="priority !== null"
+      title="Priorität"
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+    >
+      <div class="row">
+        <div class="col pr-0 text-right">Rangfolge</div>
+        <div class="col text-right text-monospace">Prio {{ priority }}</div>
+      </div>
+      <div
+        v-if="prioritySharedGroup"
+        class="row"
+      >
+        <div class="col text-right">
+          <small>Gleichrangig mit anderen Geräten der selben Gruppe.</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col text-right">
+          <small>Die Rangfolge lässt sich unter „Lastmanagement“ anpassen.</small>
+        </div>
+      </div>
+    </openwb-base-card>
   </status-card>
 </template>
 
 <script>
 import ComponentState from "../mixins/ComponentState.vue";
+import LoadManagementPriority from "../mixins/LoadManagementPriority.vue";
 import StatusCard from "./StatusCard.vue";
 
 import { library } from "@fortawesome/fontawesome-svg-core";
@@ -82,7 +115,7 @@ export default {
     StatusCard,
     FontAwesomeIcon,
   },
-  mixins: [ComponentState],
+  mixins: [ComponentState, LoadManagementPriority],
   props: {
     vehicleId: { type: Number, required: true },
   },
@@ -93,6 +126,7 @@ export default {
         { topic: `openWB/vehicle/${this.vehicleId}/info`, writeable: false },
         { topic: `openWB/vehicle/${this.vehicleId}/name`, writeable: false },
         { topic: `openWB/vehicle/${this.vehicleId}/color`, writeable: false },
+        { topic: "openWB/counter/get/loadmanagement_prios", writeable: false },
       ],
     };
   },
@@ -160,6 +194,16 @@ export default {
     baseTopic: {
       get() {
         return "openWB/vehicle/" + this.vehicleId;
+      },
+    },
+    priority: {
+      get() {
+        return this.loadManagementPriority("vehicle", this.vehicleId);
+      },
+    },
+    prioritySharedGroup: {
+      get() {
+        return this.loadManagementPriorityShared("vehicle", this.vehicleId);
       },
     },
   },

--- a/src/components/status/VehicleCard.vue
+++ b/src/components/status/VehicleCard.vue
@@ -126,7 +126,6 @@ export default {
         { topic: `openWB/vehicle/${this.vehicleId}/info`, writeable: false },
         { topic: `openWB/vehicle/${this.vehicleId}/name`, writeable: false },
         { topic: `openWB/vehicle/${this.vehicleId}/color`, writeable: false },
-        { topic: "openWB/counter/get/loadmanagement_prios", writeable: false },
       ],
     };
   },

--- a/src/views/Status.vue
+++ b/src/views/Status.vue
@@ -100,7 +100,6 @@ export default {
         { topic: "openWB/system/io/+/config", writeable: false },
         { topic: "openWB/vehicle/+/info", writeable: false },
         { topic: "openWB/consumer/+/module", writeable: false },
-        { topic: "openWB/consumer/get/power", writeable: false },
       ],
     };
   },
@@ -200,11 +199,7 @@ export default {
     },
     showConsumerSumCard: {
       get() {
-        return (
-          this.$store.state.mqtt["openWB/consumer/get/power"] !== undefined &&
-          this.$store.state.mqtt["openWB/general/extern"] === false &&
-          this.installedConsumers.length > 1
-        );
+        return this.$store.state.mqtt["openWB/general/extern"] === false && this.installedConsumers.length > 1;
       },
     },
     ioDeviceConfigs: {

--- a/src/views/Status.vue
+++ b/src/views/Status.vue
@@ -36,6 +36,14 @@
       :key="vehicleId"
       :vehicle-id="vehicleId"
     />
+    <!-- all consumers -->
+    <consumer-sum-card v-if="showConsumerSumCard" />
+    <!-- individual consumers -->
+    <consumer-card
+      v-for="consumerId in installedConsumers"
+      :key="consumerId"
+      :consumer-id="consumerId"
+    />
     <!-- io devices -->
     <io-device-card
       v-for="ioDevice in ioDeviceConfigs"
@@ -57,6 +65,8 @@ import BatterySumCard from "../components/status/BatterySumCard.vue";
 import BatteryCard from "../components/status/BatteryCard.vue";
 import IoDeviceCard from "../components/status/IoDeviceCard.vue";
 import VehicleCard from "../components/status/VehicleCard.vue";
+import ConsumerSumCard from "../components/status/ConsumerSumCard.vue";
+import ConsumerCard from "../components/status/ConsumerCard.vue";
 import ElectricityPricingCard from "../components/status/ElectricityPricingCard.vue";
 import ComponentState from "../components/mixins/ComponentState.vue";
 
@@ -72,6 +82,8 @@ export default {
     BatteryCard,
     IoDeviceCard,
     VehicleCard,
+    ConsumerSumCard,
+    ConsumerCard,
     ElectricityPricingCard,
   },
   mixins: [ComponentState],
@@ -87,6 +99,8 @@ export default {
         { topic: "openWB/system/device/+/component/+/config", writeable: false },
         { topic: "openWB/system/io/+/config", writeable: false },
         { topic: "openWB/vehicle/+/info", writeable: false },
+        { topic: "openWB/consumer/+/module", writeable: false },
+        { topic: "openWB/consumer/get/power", writeable: false },
       ],
     };
   },
@@ -169,6 +183,28 @@ export default {
           let match = topic.match(/^openWB\/vehicle\/(\d+)\/info$/);
           return match ? parseInt(match[1]) : null;
         });
+      },
+    },
+    installedConsumers: {
+      get() {
+        if (this.$store.state.mqtt["openWB/general/extern"] === true) {
+          return []; // return empty array if extern is true, no consumers should be shown
+        }
+        return Object.keys(this.getWildcardTopics("openWB/consumer/+/module"))
+          .map((topic) => {
+            let match = topic.match(/^openWB\/consumer\/(\d+)\/module$/);
+            return match ? parseInt(match[1]) : null;
+          })
+          .filter((id) => id !== null);
+      },
+    },
+    showConsumerSumCard: {
+      get() {
+        return (
+          this.$store.state.mqtt["openWB/consumer/get/power"] !== undefined &&
+          this.$store.state.mqtt["openWB/general/extern"] === false &&
+          this.installedConsumers.length > 1
+        );
       },
     },
     ioDeviceConfigs: {


### PR DESCRIPTION
Fügt Statuskarten für Verbraucher auf der Status-Seite hinzu, analog zu den bestehenden Karten für Ladepunkte, Zähler, Wechselrichter und Speicher.

- `ConsumerCard`: Einzelkarte je Verbraucher mit Leistung, Status, Betriebsmodus, Priorität und Werten pro Phase
- `ConsumerSumCard`: Summenkarte über alle Verbraucher (Gesamtleistung wird im Frontend aus den Einzelwerten summiert
- Anzeige der Priorität (aus der Lastmanagement-Prioritätenliste) auch auf der Fahrzeugkarte

<img width="1524" height="767" alt="Bildschirmfoto vom 2026-07-07 17-30-57" src="https://github.com/user-attachments/assets/9eacd22c-692a-4f52-a5de-acc58c6d59c5" />

<img width="1524" height="463" alt="Bildschirmfoto vom 2026-07-07 17-31-09" src="https://github.com/user-attachments/assets/6a392576-9d46-4c54-a8c0-1e528607177b" />
