### PR TITLE
Consumer fixes

### DIFF
--- a/src/components/consumers/ConsumerScheduledPlan.vue
+++ b/src/components/consumers/ConsumerScheduledPlan.vue
@@ -165,14 +165,6 @@ export default {
       return this.modelValue;
     },
   },
-  watch: {
-    plan: {
-      handler(newValue) {
-        this.$emit("update:modelValue", newValue);
-      },
-      deep: true,
-    },
-  },
   methods: {
     copyPlan() {
       this.$emit("sendCommand", {

--- a/src/components/consumers/ConsumerTimeChargingPlan.vue
+++ b/src/components/consumers/ConsumerTimeChargingPlan.vue
@@ -121,7 +121,7 @@
       :labels="minBatSocLabels"
     >
       <template #help>
-        Zeitladen wird nur ausgeführt, solange der Speicher-SoC über diesem Wert liegt. Bei „Aus" wird der Speicher-SoC
+        Zeitladen wird nur ausgeführt, solange der Speicher-SoC über diesem Wert liegt. Bei „Aus“ wird der Speicher-SoC
         nicht berücksichtigt. Lädt die aktive Speichersteuerung gerade den Speicher, wird kein Zeitladen gestartet, da
         der Speicher nicht gleichzeitig geladen und entladen werden kann.
       </template>

--- a/src/components/consumers/ConsumerTimeChargingPlan.vue
+++ b/src/components/consumers/ConsumerTimeChargingPlan.vue
@@ -121,7 +121,7 @@
       :labels="minBatSocLabels"
     >
       <template #help>
-        Zeitladen wird nur ausgeführt, solange der Speicher-SoC über diesem Wert liegt. Bei „Aus“ wird der Speicher-SoC
+        Zeitladen wird nur ausgeführt, solange der Speicher-SoC über diesem Wert liegt. Bei "Aus" wird der Speicher-SoC
         nicht berücksichtigt. Lädt die aktive Speichersteuerung gerade den Speicher, wird kein Zeitladen gestartet, da
         der Speicher nicht gleichzeitig geladen und entladen werden kann.
       </template>

--- a/src/components/consumers/ConsumerTimeChargingPlan.vue
+++ b/src/components/consumers/ConsumerTimeChargingPlan.vue
@@ -181,14 +181,6 @@ export default {
       return labels;
     },
   },
-  watch: {
-    plan: {
-      handler(newValue) {
-        this.$emit("update:modelValue", newValue);
-      },
-      deep: true,
-    },
-  },
   methods: {
     copyPlan() {
       this.$emit("sendCommand", {

--- a/src/components/consumers/OpenwbConsumerDeviceConfigFallback.vue
+++ b/src/components/consumers/OpenwbConsumerDeviceConfigFallback.vue
@@ -1,23 +1,23 @@
 <template>
-  <div class="device-fallback">
+  <div class="consumer-device-fallback">
     <openwb-base-alert
       v-if="Object.keys(device.configuration).length == 0"
       subtype="info"
     >
-      Der Gerät-Typ "{{ device.type }}" bietet keine Einstellungen.
+      Der Verbraucher-Typ "{{ device.type }}" bietet keine Einstellungen.
     </openwb-base-alert>
     <div v-else>
       <openwb-base-alert subtype="warning">
-        Es wurde keine Konfigurationsseite für den Geräte-Typ "{{ device.type }}" gefunden. Die Einstellungen können als
-        JSON direkt bearbeitet werden.
+        Es wurde keine Konfigurationsseite für den Verbraucher-Typ "{{ device.type }}" gefunden. Die Einstellungen
+        können als JSON direkt bearbeitet werden.
       </openwb-base-alert>
       <openwb-base-textarea
         title="Konfiguration"
         subtype="json"
         :model-value="device.configuration"
-        @update:model-value="updateFallbackConfiguration($event)"
+        @update:model-value="updateConfiguration($event, 'configuration')"
       >
-        <template #help> Bitte prüfen Sie, ob die Eingaben richtig interpretiert werden. </template>
+        <template #help> Bitte prüfe, ob die Eingaben richtig interpretiert werden. </template>
       </openwb-base-textarea>
       <openwb-base-alert subtype="info">
         <pre>{{ JSON.stringify(device.configuration, undefined, 2) }}</pre>
@@ -27,19 +27,10 @@
 </template>
 
 <script>
+import ConsumerDeviceConfigMixin from "./ConsumerDeviceConfigMixin.vue";
+
 export default {
-  name: "DeviceFallback",
-  props: {
-    device: { type: Object, required: true },
-  },
-  emits: ["update:configuration"],
-  methods: {
-    updateFallbackConfiguration(value) {
-      this.$emit("update:configuration", {
-        value,
-        object: "configuration",
-      });
-    },
-  },
+  name: "ConsumerDeviceFallback",
+  mixins: [ConsumerDeviceConfigMixin],
 };
 </script>

--- a/src/components/devices/OpenwbDeviceConfigFallback.vue
+++ b/src/components/devices/OpenwbDeviceConfigFallback.vue
@@ -15,7 +15,7 @@
         title="Konfiguration"
         subtype="json"
         :model-value="device.configuration"
-        @update:model-value="updateFallbackConfiguration($event)"
+        @update:model-value="updateConfiguration($event, 'configuration')"
       >
         <template #help> Bitte prüfe, ob die Eingaben richtig interpretiert werden. </template>
       </openwb-base-textarea>
@@ -27,20 +27,10 @@
 </template>
 
 <script>
+import DeviceConfigMixin from "./DeviceConfigMixin.vue";
+
 export default {
   name: "DeviceFallback",
-  props: {
-    device: { type: Object, required: true },
-  },
-  emits: ["update:configuration"],
-  methods: {
-    updateFallbackConfiguration(value) {
-      this.$emit("update:configuration", {
-        value,
-        object: "configuration",
-        source: "fallback",
-      });
-    },
-  },
+  mixins: [DeviceConfigMixin],
 };
 </script>

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -15,7 +15,7 @@
     <openwb-base-alert subtype="info">
       Das Einschalten der Verbraucher richtet sich nach der Rangfolge in der Prioritäten-Steuerung (Geräte werden von
       oben nach unten geschaltet) und dem Mindeststrom des jeweiligen Geräts: Bei geringem Überschuss wird das erste
-      Gerät in der Liste geschaltet, dessen Mindeststrom erreicht ist. Die Rangfolge lässt sich unter „Lastmanagement“
+      Gerät in der Liste geschaltet, dessen Mindeststrom erreicht ist. Die Rangfolge lässt sich unter "Lastmanagement"
       anpassen.
     </openwb-base-alert>
     <form name="consumerConfigForm">
@@ -527,9 +527,9 @@
             <hr />
             <openwb-base-heading> Separate Leistungsmessung </openwb-base-heading>
             <openwb-base-alert subtype="info">
-              Lege den Zähler zuerst unter „Geräte und Komponenten“ an und verknüpfe ihn anschließend hier mit dem
-              Verbraucher. Der EVU-Zähler sowie Zähler, die bereits einem anderen Verbraucher zugeordnet sind, stehen
-              nicht zur Auswahl.
+              Lege den Zähler zuerst unter <router-link to="/HardwareInstallation">Geräte und Komponenten</router-link>
+              an und verknüpfe ihn anschließend hier mit dem Verbraucher. Der EVU-Zähler sowie Zähler, die bereits einem
+              anderen Verbraucher zugeordnet sind, stehen nicht zur Auswahl.
             </openwb-base-alert>
             <openwb-base-select-input
               title="Zähler"
@@ -539,7 +539,7 @@
             >
               <template #help>
                 Der ausgewählte Zähler überschreibt die Messwerte eines ggf. integrierten Zählers. Konfiguriert wird der
-                Zähler unter „Geräte und Komponenten“.
+                Zähler unter "Geräte und Komponenten".
               </template>
             </openwb-base-select-input>
           </openwb-base-card>

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -7,8 +7,8 @@
     :buttons="[{ text: 'Löschen', event: 'confirm', subtype: 'danger' }]"
     @modal-result="removeConsumer"
   >
-    Wollen Sie den Verbraucher "{{ modalConsumerName }}" wirklich entfernen? Dieser Vorgang kann nicht rückgängig
-    gemacht werden!
+    Willst Du den Verbraucher "{{ modalConsumerName }}" wirklich entfernen? Dieser Vorgang kann nicht rückgängig gemacht
+    werden!
   </openwb-base-modal-dialog>
   <!-- main content -->
   <div class="consumerConfig">
@@ -527,9 +527,9 @@
             <hr />
             <openwb-base-heading> Separate Leistungsmessung </openwb-base-heading>
             <openwb-base-alert subtype="info">
-              Legen Sie den Zähler zuerst unter „Geräte und Komponenten" an und verknüpfen Sie ihn anschließend hier mit
-              dem Verbraucher. Der EVU-Zähler sowie Zähler, die bereits einem anderen Verbraucher zugeordnet sind,
-              stehen nicht zur Auswahl.
+              Lege den Zähler zuerst unter „Geräte und Komponenten“ an und verknüpfe ihn anschließend hier mit dem
+              Verbraucher. Der EVU-Zähler sowie Zähler, die bereits einem anderen Verbraucher zugeordnet sind, stehen
+              nicht zur Auswahl.
             </openwb-base-alert>
             <openwb-base-select-input
               title="Zähler"
@@ -539,7 +539,7 @@
             >
               <template #help>
                 Der ausgewählte Zähler überschreibt die Messwerte eines ggf. integrierten Zählers. Konfiguriert wird der
-                Zähler unter „Geräte und Komponenten".
+                Zähler unter „Geräte und Komponenten“.
               </template>
             </openwb-base-select-input>
           </openwb-base-card>


### PR DESCRIPTION
Consumer Pläne - Watcher entfernt. Einen Setter habe ich bewusst nicht ergänzt: Er würde nie ausgelöst, da im Template ausschließlich verschachtelte Properties geschrieben werden (plan.name, plan.active, …). plan ist eine Referenz auf das Objekt im Store, Änderungen landen also ohnehin direkt dort — der Watcher hat das Objekt nur auf sich selbst zurückgeschrieben.

Damit sind emits: ["update:modelValue"] und der @update:model-value-Handler im Parent tot. auch entfernen?
Das gleiche Muster steckt in ChargeTemplateScheduledChargingPlan, ChargeTemplateTimeChargingPlan und TemplateAutoLockPlan. Dort ebenfalls anpassen?


Fallback-Komponenten

OpenwbConsumerDeviceConfigFallback nutzt jetzt das ConsumerDeviceConfigMixin und updateConfiguration(). Komponentenname sind entsprechend auf consumer-device-fallback bzw. ConsumerDeviceFallback angepasst.

Im Geräte-Fallback ist die Mixin-Nutzung beim Übernehmen des Musters in #1001 verloren gegangen. Sie ist wieder hergestellt, die Datei entspricht damit wieder dem Stand von main.

Texte angepasst: 

„Gerät-Typ“ → „Verbraucher-Typ“ im Verbraucher-Fallback
Sie-Form → Du-Form 