### PR TITLE
Consumer UI fix

### DIFF
--- a/src/components/status/ConsumerCard.vue
+++ b/src/components/status/ConsumerCard.vue
@@ -29,16 +29,13 @@
     </template>
     <!-- Status -->
     <openwb-base-card
+      v-if="statusMessage"
+      title="Status"
       subtype="white"
       body-bg="white"
       class="py-1 mb-2"
     >
-      <div class="row py-2">
-        <div class="col col-auto font-weight-bold">Status</div>
-        <div class="col text-right">{{ statusText }}</div>
-      </div>
       <openwb-base-alert
-        v-if="statusMessage"
         subtype="info"
         class="mb-0"
       >
@@ -217,15 +214,6 @@ export default {
     power: {
       get() {
         return this.formatNumberTopic(this.baseTopic + "/get/power", 3, 3, 0.001);
-      },
-    },
-    statusText: {
-      get() {
-        const power = this.$store.state.mqtt[this.baseTopic + "/get/power"];
-        if (power === undefined) {
-          return "-";
-        }
-        return power > 0 ? "Eingeschaltet" : "Ausgeschaltet";
       },
     },
     statusMessage: {

--- a/src/components/status/ConsumerCard.vue
+++ b/src/components/status/ConsumerCard.vue
@@ -27,6 +27,26 @@
       </span>
       {{ power }}&nbsp;kW
     </template>
+    <!-- Status -->
+    <openwb-base-card
+      subtype="white"
+      body-bg="white"
+      class="py-1 mb-2"
+    >
+      <div class="row py-2">
+        <div class="col col-auto font-weight-bold">Status</div>
+        <div class="col text-right">{{ statusText }}</div>
+      </div>
+      <openwb-base-alert
+        v-if="statusMessage"
+        subtype="info"
+        class="mb-0"
+      >
+        Statusmeldung:
+        <span style="white-space: pre-wrap">{{ statusMessage }}</span>
+      </openwb-base-alert>
+    </openwb-base-card>
+    <!-- Aktuelle Werte -->
     <openwb-base-card
       title="Aktuelle Werte"
       subtype="white"
@@ -36,10 +56,6 @@
       <div class="row">
         <div class="col pr-0 text-right">Leistung</div>
         <div class="col text-right text-monospace">{{ power }}&nbsp;kW</div>
-      </div>
-      <div class="row">
-        <div class="col pr-0 text-right">Status</div>
-        <div class="col text-right text-monospace">{{ statusText }}</div>
       </div>
       <div
         v-if="chargemode !== null"
@@ -205,15 +221,16 @@ export default {
     },
     statusText: {
       get() {
-        const stateString = this.$store.state.mqtt[this.baseTopic + "/get/state_str"];
-        if (stateString) {
-          return stateString;
-        }
-        const state = this.$store.state.mqtt[this.baseTopic + "/get/state"];
-        if (state === undefined) {
+        const power = this.$store.state.mqtt[this.baseTopic + "/get/power"];
+        if (power === undefined) {
           return "-";
         }
-        return state ? "Eingeschaltet" : "Ausgeschaltet";
+        return power > 0 ? "Eingeschaltet" : "Ausgeschaltet";
+      },
+    },
+    statusMessage: {
+      get() {
+        return this.$store.state.mqtt[this.baseTopic + "/get/state_str"] ?? null;
       },
     },
     chargemode: {

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -129,6 +129,25 @@
               @update:configuration="consumerDeviceConfiguration(installedConsumer, $event)"
             />
             <hr />
+            <openwb-base-heading> Verwendung Optionen </openwb-base-heading>
+            <openwb-base-select-input
+              title="Verwendung"
+              not-selected="Bitte auswählen"
+              :options="getUsageOptions(installedConsumer)"
+              :model-value="installedConsumer.consumerUsage?.type"
+              @update:model-value="updateUsage(installedConsumer.id, $event, 'type')"
+            >
+              <template #help>
+                Nur Messung: Verbraucher, die nicht angesteuert werden können.<br />
+                Schaltbar (Ein/Aus): Geräte, die ein- und ausgeschaltet werden können (auch mit SG-Ready-Kontakt).
+                Unterbrechung im laufenden Betrieb ist möglich.<br />
+                Stufenlos regelbar: Geräte, denen eine Leistung vorgegeben werden kann. Unterbrechung im laufenden
+                Betrieb ist möglich.<br />
+                Dauerverbraucher: Geräte, die ein- und ausgeschaltet werden können, bei denen eine Unterbrechung im
+                laufenden Betrieb nicht möglich ist, z. B. Spülmaschine oder Trockner.
+              </template>
+            </openwb-base-select-input>
+            <hr />
             <openwb-base-heading> Elektrischer Anschluss </openwb-base-heading>
             <openwb-base-button-group-input
               title="Anzahl angeschlossener Phasen"
@@ -208,25 +227,6 @@
                 </span>
               </template>
             </openwb-base-number-input>
-            <hr />
-            <openwb-base-heading> Verwendung Optionen </openwb-base-heading>
-            <openwb-base-select-input
-              title="Verwendung"
-              not-selected="Bitte auswählen"
-              :options="getUsageOptions(installedConsumer)"
-              :model-value="installedConsumer.consumerUsage?.type"
-              @update:model-value="updateUsage(installedConsumer.id, $event, 'type')"
-            >
-              <template #help>
-                Nur Messung: Verbraucher, die nicht angesteuert werden können.<br />
-                Schaltbar (Ein/Aus): Geräte, die ein- und ausgeschaltet werden können (auch mit SG-Ready-Kontakt).
-                Unterbrechung im laufenden Betrieb ist möglich.<br />
-                Stufenlos regelbar: Geräte, denen eine Leistung vorgegeben werden kann. Unterbrechung im laufenden
-                Betrieb ist möglich.<br />
-                Dauerverbraucher: Geräte, die ein- und ausgeschaltet werden können, bei denen eine Unterbrechung im
-                laufenden Betrieb nicht möglich ist, z. B. Spülmaschine oder Trockner.
-              </template>
-            </openwb-base-select-input>
             <template v-if="showModeSettings(installedConsumer)">
               <hr />
               <openwb-base-heading> Betriebsmodus </openwb-base-heading>

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -213,13 +213,8 @@
             <openwb-base-select-input
               title="Verwendung"
               not-selected="Bitte auswählen"
-              :options="[
-                { value: 'meter_only', text: 'Nur Messung' },
-                { value: 'suspendable_onoff', text: 'Schaltbar (Ein/Aus)' },
-                { value: 'suspendable_tunable', text: 'Stufenlos regelbar' },
-                { value: 'continuous', text: 'Dauerverbraucher' },
-              ]"
-              :model-value="installedConsumer.consumerUsage.type"
+              :options="getUsageOptions(installedConsumer)"
+              :model-value="installedConsumer.consumerUsage?.type"
               @update:model-value="updateUsage(installedConsumer.id, $event, 'type')"
             >
               <template #help>
@@ -858,6 +853,22 @@ export default {
     showModeSettings(consumer) {
       const type = consumer.consumerUsage?.type;
       return type != null && type !== "meter_only";
+    },
+    getUsageOptions(consumer) {
+      if (!Array.isArray(consumer.usage)) return [];
+      return consumer.usage.map((use) => ({
+        value: use,
+        text: this.usageLabels(use),
+      }));
+    },
+    usageLabels(type) {
+      const map = {
+        meter_only: "Nur Messung",
+        suspendable_onoff: "Schaltbar (Ein/Aus)",
+        suspendable_tunable: "Stufenlos regelbar",
+        continuous: "Dauerverbraucher",
+      };
+      return map[type] ?? type;
     },
     updateUsage(consumerId, value, path) {
       this.updateState(`openWB/consumer/${consumerId}/usage`, value, path);

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -865,7 +865,7 @@ export default {
     },
     showMinCurrent(consumer) {
       const type = consumer.consumerUsage?.type;
-      return type !== "suspendable_onoff" && type !== "continuous";
+      return type !== "suspendable_onoff" && type !== "continuous" && type !== "meter_only";
     },
     getUsageOptions(consumer) {
       if (!Array.isArray(consumer.usage)) return [];

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -167,7 +167,7 @@
               </template>
             </openwb-base-number-input>
             <openwb-base-number-input
-              v-if="showModeSettings(installedConsumer)"
+              v-if="showMinCurrent(installedConsumer)"
               title="Minimaler Betriebsstrom"
               unit="A"
               :min="0"
@@ -853,6 +853,10 @@ export default {
     showModeSettings(consumer) {
       const type = consumer.consumerUsage?.type;
       return type != null && type !== "meter_only";
+    },
+    showMinCurrent(consumer) {
+      const type = consumer.consumerUsage?.type;
+      return type !== "suspendable_onoff" && type !== "continuous";
     },
     getUsageOptions(consumer) {
       if (!Array.isArray(consumer.usage)) return [];

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -771,7 +771,7 @@ export default {
     hasIntegratedCounter() {
       const result = {};
       Object.values(this.installedConsumers).forEach((consumer) => {
-        result[consumer.id] = consumer?.consumerUsage?.type === "meter_only";
+        result[consumer.id] = consumer?.usage?.includes("meter_only") ?? false;
       });
       return result;
     },

--- a/src/views/ConsumerConfig.vue
+++ b/src/views/ConsumerConfig.vue
@@ -484,6 +484,14 @@
                     ein Strompreis-Anbieter konfiguriert sein.
                   </template>
                 </openwb-base-number-input>
+                <openwb-base-alert
+                  v-if="!$store.state.mqtt['openWB/optional/ep/configured']"
+                  class="mt-2"
+                  subtype="warning"
+                >
+                  Bitte in den übergreifenden Ladeeinstellungen einen Strompreis-Anbieter konfigurieren. Ohne
+                  Strompreis-Anbieter wird das Gerät im Modus Eco nur eingeschaltet, wenn Überschuss vorhanden ist.
+                </openwb-base-alert>
               </openwb-base-card>
               <hr />
               <openwb-base-heading> Zeit-Pläne </openwb-base-heading>
@@ -658,6 +666,7 @@ export default {
         { topic: "openWB/general/consumer/config/switch_off_delay", writeable: true },
         { topic: "openWB/general/consumer/config/switch_off_threshold", writeable: true },
         { topic: "openWB/system/configurable/consumers", writeable: false },
+        { topic: "openWB/optional/ep/configured", writeable: false },
       ],
       selectedVendor: undefined,
       consumerToAdd: undefined,


### PR DESCRIPTION
Verwendungs-Dropdown filtert wieder nach den Fähigkeiten des Geräts (module-Topic, Key usage) statt fest hinterlegter Liste
hasIntegratedCounter liest wieder das Fähigkeits-Array (usage) statt des ausgewählten Typs (consumerUsage.type) – sonst falsche Zähler-Hinweise bei z. B. Shelly PM
Min. Betriebsstrom bei „Schaltbar (Ein/Aus)" und „Dauerverbraucher" ausgeblendet
Eco: Hinweis ergänzt, wenn kein Strompreis-Anbieter konfiguriert ist
Status-Karte aktualisiert