### PR TITLE
Fix CP Interrupt retry

### DIFF
--- a/src/views/VehicleConfiguration.vue
+++ b/src/views/VehicleConfiguration.vue
@@ -591,8 +591,8 @@
               v-if="template.control_pilot_interruption"
               title="Wiederholung der CP-Unterbrechung"
               :min="0"
-              :max="1200"
-              :step="60"
+              :max="20"
+              :step="1"
               unit="min"
               :labels="[
                 { label: 'Aus', value: 0 },


### PR DESCRIPTION
Hat im UI nicht funktioniert, falsche max und step Werte definiert.